### PR TITLE
fix: exclude node dependencies from dev bundle

### DIFF
--- a/packages/build/src/build-watch.ts
+++ b/packages/build/src/build-watch.ts
@@ -10,6 +10,8 @@ const main = async (): Promise<void> => {
     [
       '--format=esm',
       '--bundle',
+      '--external:electron',
+      '--external:node:*',
       '--watch',
       'packages/extension/src/languageFeaturesTypeScriptMain.ts',
       '--outfile=packages/extension/dist/languageFeaturesTypeScriptMain.js',


### PR DESCRIPTION
Exclude Electron and Node built-ins from the extension watch bundle, matching the production esbuild configuration so local development can start successfully.