### PR TITLE
fix: enable typescript diagnostics e2e test

### DIFF
--- a/packages/e2e/src/typescript.diagnostics.ts
+++ b/packages/e2e/src/typescript.diagnostics.ts
@@ -2,27 +2,29 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'typescript.diagnostics'
 
-export const skip = 1
-
-export const test: Test = async ({ Editor, FileSystem, Workspace, Main }) => {
+export const test: Test = async ({ Editor, FileSystem, Main, Settings, Workspace }) => {
   // arrange
   const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
   const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
   await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
 
   // act
   await Main.openUri(`${workspaceUrl}/src/test.ts`)
 
   // assert
-  // @ts-ignore
-  await Editor.shouldHaveDiagnostics([
+  const expectedDiagnostics = [
     {
-      rowIndex: 1,
+      code: 2322,
       columnIndex: -1,
-      endRowIndex: 1,
       endColumnIndex: 0,
+      endRowIndex: 1,
       message: "Type 'string' is not assignable to type 'number'.",
+      rowIndex: 1,
+      source: 'ts',
       type: 'error',
+      uri: `${workspaceUrl}/src/test.ts`,
     },
-  ])
+  ] as const
+  await Editor.shouldHaveDiagnostics(expectedDiagnostics)
 }

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/server": "^0.87.1"
+        "@lvce-editor/server": "^0.87.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -85,9 +85,9 @@
       }
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.87.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.87.1.tgz",
-      "integrity": "sha512-revMcZcipCz2A4OTCGA2Vz3JLvkD0HRyWgMAOa50VAzggJV4yCvD35rSpb6WfDP2oAMVfj8wnYBQO0rQsQ9tnA==",
+      "version": "0.87.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.87.2.tgz",
+      "integrity": "sha512-YjVOw6skDDYj1W5e+KxJwidfy+wcvuL8tfunr7o0bO0A2rBC607Cz/ghS2i6RSx5vJScBAdKSixSg++4p2Fo/w==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.7.0",
@@ -493,13 +493,13 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.87.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.87.1.tgz",
-      "integrity": "sha512-2hHSdYjxquv+M3Jb+yf9lbhu/4qqnnBIjUvd2iMsnniSps30wCvuWE4wbACcLoPg5wKePctvXxBLqwnJgZO2fQ==",
+      "version": "0.87.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.87.2.tgz",
+      "integrity": "sha512-7ti9hCKlvYOCN6novm31bugn8jBLEcpzpxFcJe18EfKBjF+Vhd/Nu7uwxYqCdzpVINmBmVGIXkYMg0I0EBCrlw==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.87.1",
-        "@lvce-editor/static-server": "0.87.1"
+        "@lvce-editor/shared-process": "0.87.2",
+        "@lvce-editor/static-server": "0.87.2"
       },
       "bin": {
         "server": "bin/server.js"
@@ -509,14 +509,14 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.87.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.87.1.tgz",
-      "integrity": "sha512-OOlVK3Ik2iHpcZLAerf/wTgiBNbYY79H8qTReuW378KYUipS77+KPBTiJQcMgaO5Q1VF1FiojiwIb1k8L35iZA==",
+      "version": "0.87.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.87.2.tgz",
+      "integrity": "sha512-VDHR1BFI4akcevx1niWb1+2nZPZQFLlj06bIzJ+q6BGzH4EarJCmUEZsL3IFEq8SV7Og5kmNhP0L4y8qih7BBw==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.7.0",
         "@lvce-editor/auth-process": "1.8.0",
-        "@lvce-editor/extension-host-helper-process": "0.87.1",
+        "@lvce-editor/extension-host-helper-process": "0.87.2",
         "@lvce-editor/ipc": "16.3.0",
         "@lvce-editor/json-rpc": "8.2.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -547,9 +547,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.87.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.87.1.tgz",
-      "integrity": "sha512-ClEllbZYuyHw95SMKDk4XaGGWphOetxbs89elkwK2d3VlEWxtJBlr5tSh7GOf0NJ+UjziGQLuUwkte2cdj536g==",
+      "version": "0.87.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.87.2.tgz",
+      "integrity": "sha512-eT6ExhVKUVdWyHN7vLSNVwAuT71qKKfxKix6W5XwGcR/qiJXwpK1ivG78HjxwK8z8Su5hNS4ItJpjQA6oUYZPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=24"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@lvce-editor/server": "^0.87.1"
+    "@lvce-editor/server": "^0.87.2"
   }
 }


### PR DESCRIPTION
Enable the TypeScript diagnostics regression and verify the complete diagnostic returned for an opened TypeScript file.