### PR TITLE
Enable TypeScript auto-fix imports e2e test

### DIFF
--- a/packages/e2e/fixtures/auto-fix-imports/src/math.ts
+++ b/packages/e2e/fixtures/auto-fix-imports/src/math.ts
@@ -1,0 +1,3 @@
+export const add = (a: number, b: number): number => a + b
+
+export const subtract = (a: number, b: number): number => a - b

--- a/packages/e2e/fixtures/auto-fix-imports/src/test.ts
+++ b/packages/e2e/fixtures/auto-fix-imports/src/test.ts
@@ -1,1 +1,3 @@
 import { add, subtract } from './math.ts'
+
+add(1, 2)

--- a/packages/e2e/src/typescript.auto-fix-imports.ts
+++ b/packages/e2e/src/typescript.auto-fix-imports.ts
@@ -2,10 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'typescript.auto-fix-import'
 
-// TODO enable when source-action widgets support isolated code-action providers
-export const skip = 1
-
-export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main, Workspace }) => {
+export const test: Test = async ({ Command, Editor, expect, FileSystem, Locator, Main, Workspace }) => {
   // arrange
   const fixtureUrl = import.meta.resolve('../fixtures/auto-fix-imports')
   const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
@@ -19,11 +16,11 @@ export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main, Wo
   // assert
   const organizeImportsAction = Locator('.SourceActionItem', { hasText: 'Organize Imports' })
   await expect(organizeImportsAction).toBeVisible()
-  // @ts-ignore
-  // eslint-disable-next-line e2e/no-direct-click
-  await organizeImportsAction.click()
+  await Command.execute('EditorSourceAction.selectItem', 'Organize Imports')
 
   // assert
+  await Editor.shouldHaveText(`import { add } from './math.ts'
 
-  // TODO verify that unused imports  have been removed
+add(1, 2)
+`)
 }

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/server": "^0.87.2"
+        "@lvce-editor/server": "^0.87.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -85,9 +85,9 @@
       }
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.87.2",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.87.2.tgz",
-      "integrity": "sha512-YjVOw6skDDYj1W5e+KxJwidfy+wcvuL8tfunr7o0bO0A2rBC607Cz/ghS2i6RSx5vJScBAdKSixSg++4p2Fo/w==",
+      "version": "0.87.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.87.3.tgz",
+      "integrity": "sha512-HtBxEDBdkkVuIm8jUc6/D+YQYxWetik8+KG+GxGaCYH1J0YbL7BK8bgBmgNKGeaS4G3y2uFD4/WXSPQJK1zKng==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.7.0",
@@ -493,13 +493,13 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.87.2",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.87.2.tgz",
-      "integrity": "sha512-7ti9hCKlvYOCN6novm31bugn8jBLEcpzpxFcJe18EfKBjF+Vhd/Nu7uwxYqCdzpVINmBmVGIXkYMg0I0EBCrlw==",
+      "version": "0.87.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.87.3.tgz",
+      "integrity": "sha512-7DMmVOeYljeE4dwJyAQxUPstraJYLRybrmPUJj+VYrLAVT8yTgaqIQpoy+HCfY8Wq07gh7DijHD/glJ+4kjrlA==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.87.2",
-        "@lvce-editor/static-server": "0.87.2"
+        "@lvce-editor/shared-process": "0.87.3",
+        "@lvce-editor/static-server": "0.87.3"
       },
       "bin": {
         "server": "bin/server.js"
@@ -509,14 +509,14 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.87.2",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.87.2.tgz",
-      "integrity": "sha512-VDHR1BFI4akcevx1niWb1+2nZPZQFLlj06bIzJ+q6BGzH4EarJCmUEZsL3IFEq8SV7Og5kmNhP0L4y8qih7BBw==",
+      "version": "0.87.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.87.3.tgz",
+      "integrity": "sha512-naAEhE+7/A1YVqL8m81eBGVXvXrWhdYYpicBbzAwB0QSkuJ/ZQtksRuj1ywvr3BPlR6bC7798Bmy8uLwfrtd4g==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.7.0",
         "@lvce-editor/auth-process": "1.8.0",
-        "@lvce-editor/extension-host-helper-process": "0.87.2",
+        "@lvce-editor/extension-host-helper-process": "0.87.3",
         "@lvce-editor/ipc": "16.3.0",
         "@lvce-editor/json-rpc": "8.2.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -547,9 +547,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.87.2",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.87.2.tgz",
-      "integrity": "sha512-eT6ExhVKUVdWyHN7vLSNVwAuT71qKKfxKix6W5XwGcR/qiJXwpK1ivG78HjxwK8z8Su5hNS4ItJpjQA6oUYZPQ==",
+      "version": "0.87.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.87.3.tgz",
+      "integrity": "sha512-rXEChvFqrZrVI/cCfnQKphsr8LvbwxWETg5j4O0EiCN/MhiQuYvxHxN/LkYbUmsKe52OyBNnVc4MjHUTnXZiLA==",
       "license": "MIT",
       "engines": {
         "node": ">=24"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@lvce-editor/server": "^0.87.2"
+    "@lvce-editor/server": "^0.87.3"
   }
 }


### PR DESCRIPTION
Enables the TypeScript auto-fix-imports e2e coverage and verifies that selecting Organize Imports from the source-action widget removes the unused import.