### PR TITLE
fix: enable completion end-to-end tests

### DIFF
--- a/packages/e2e/src/typescript.auto-import-no-suggestions.ts
+++ b/packages/e2e/src/typescript.auto-import-no-suggestions.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'typescript.auto-import-no-suggestions'
 
-export const skip = 1
-
 export const test: Test = async ({ Workspace, FileSystem, Main, Editor, Locator, expect }) => {
   // arrange
   const fixtureUrl = import.meta.resolve('../fixtures/auto-import-no-suggestions')

--- a/packages/e2e/src/typescript.auto-import.ts
+++ b/packages/e2e/src/typescript.auto-import.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'typescript.auto-import'
 
-export const skip = 1
-
 export const test: Test = async ({ FileSystem, Workspace, Main, Editor, Locator, expect }) => {
   // arrange
   const fixtureUrl = import.meta.resolve('../fixtures/auto-import')

--- a/packages/e2e/src/typescript.brace-completion.ts
+++ b/packages/e2e/src/typescript.brace-completion.ts
@@ -2,14 +2,17 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'typescript.brace-completion'
 
-export const skip = true
-
 export const test: Test = async ({ FileSystem, Workspace, Main, Editor }) => {
   // arrange
-  const fixtureUrl = import.meta.resolve('../fixtures/auto-fix-spelling')
+  const fixtureUrl = import.meta.resolve('../fixtures/brace-completion')
   const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
   await Workspace.setPath(workspaceUrl)
-  await Main.openUri(`${workspaceUrl}/test.ts`)
-  await Editor.setCursor(0, 0)
-  // TODO
+  await Main.openUri(`${workspaceUrl}/src/test.ts`)
+  await Editor.setCursor(0, 3)
+
+  // act
+  await Editor.invokeBraceCompletion('{')
+
+  // assert
+  await Editor.shouldHaveText('win{}\n')
 }

--- a/packages/extension/src/parts/ExtensionHost/ExtensionHostBraceCompletionProviderTypeScript.ts
+++ b/packages/extension/src/parts/ExtensionHost/ExtensionHostBraceCompletionProviderTypeScript.ts
@@ -1,20 +1,9 @@
-// @ts-nocheck
-import * as Position from '../Position/Position.ts'
-import * as TsServerRequests from '../TsServerRequests/TsServerRequests.ts'
-
-export const languageId = 'typescript'
+import * as TypeScriptWorker from '../TypeScriptWorker/TypeScriptWorker.ts'
 
 /**
  * @type {vscode.BraceCompletionProvider['provideBraceCompletion']}
  */
 export const provideBraceCompletion = async (textDocument: any, offset: number, openingBrace: string): Promise<any> => {
-  console.warn('typescript brace completion', textDocument)
-  const tsPosition = Position.getTsPosition(textDocument, offset)
-  const shouldDoBraceCompletion = await TsServerRequests.braceCompletion({
-    file: textDocument.uri,
-    openingBrace,
-    line: tsPosition.line,
-    offset: tsPosition.offset,
-  })
-  return shouldDoBraceCompletion
+  const worker = await TypeScriptWorker.getInstance()
+  return worker.invoke('BraceCompletion.provide', textDocument, offset, openingBrace)
 }

--- a/packages/extension/src/parts/Providers/Providers.ts
+++ b/packages/extension/src/parts/Providers/Providers.ts
@@ -1,3 +1,4 @@
+export * as BraceCompletionProvider from '../ExtensionHost/ExtensionHostBraceCompletionProviderTypeScript.ts'
 export * as CodeActionsProvider from '../ExtensionHost/ExtensionHostCodeActionsProviderTypeScript.ts'
 export * as CommentProvider from '../ExtensionHost/ExtensionHostCommentProviderTypeScript.ts'
 export * as CompletionProvider from '../ExtensionHost/ExtensionHostCompletionProviderTypeScript.ts'

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/server": "^0.87.3"
+        "@lvce-editor/server": "^0.91.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -48,9 +48,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/auth-process": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/auth-process/-/auth-process-1.8.0.tgz",
-      "integrity": "sha512-hUd4Rtu0YC0gc9ljow90sUAhmYg+F2Txm4jO5wsiKVWl14Av+XKY27HNYaviGysnYMjngNAoIztku5Q6jmu/UQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/auth-process/-/auth-process-1.9.0.tgz",
+      "integrity": "sha512-ISmJm47TYZ/WqOWp+8CFVD8CQXVkzuu18L8qiT50sjqtMPfOg9zQ6DWehAWZcDtCP//GYavMlpz0KkJIXcuCMw==",
       "license": "MIT",
       "bin": {
         "auth-process": "bin/oauthProcess.js"
@@ -72,9 +72,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.9.0.tgz",
-      "integrity": "sha512-1UwiXbA9zXu8lA+kK/+IH0H9nBSX8Zjkq2IuDx8it8KkI0tOsHuy5IFIxKwkVQgfobmCpUA3/9M4Iv5GVgJWBQ==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.9.1.tgz",
+      "integrity": "sha512-YkwhW4R48MA2kXlxxIBNWMTTYg1FZlUT4bjJSCeUENLYbltv2KWXgdWF8Giysys/V0RzX6zbJqkdOiiO6qyJLQ==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -85,9 +85,9 @@
       }
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.87.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.87.3.tgz",
-      "integrity": "sha512-HtBxEDBdkkVuIm8jUc6/D+YQYxWetik8+KG+GxGaCYH1J0YbL7BK8bgBmgNKGeaS4G3y2uFD4/WXSPQJK1zKng==",
+      "version": "0.91.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.91.3.tgz",
+      "integrity": "sha512-sYD7aOpXS80pKyStZu0rYKlZ/yT0AziNeX4IPBKkcfOBcziOQsN6pVdFGQHiYem5ZtEOW5aRSaQ/K0eymzepOA==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.7.0",
@@ -102,9 +102,9 @@
       }
     },
     "node_modules/@lvce-editor/file-system-process": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.3.0.tgz",
-      "integrity": "sha512-ztNyEgKB3v57VqcdwMD7Q1sWro/Xz3KtJrYuXRY+STNEEf/DvOHv2VJva6W0o/63dmGqdqRkxstuuBZbuUnlng==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.4.0.tgz",
+      "integrity": "sha512-QeaqkR61uMQFiV7S182isrn8XhaA1o6TyU7liGM7gZMJmmK4nma9vneeqC2yJFxNP+nJws8sMq/B+z53qEADEg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@lvce-editor/file-watcher-process": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.2.0.tgz",
-      "integrity": "sha512-DcR4HT4l/hzONyEs80vd7mQ+bqyR5AxAqEclB+ginm3nFwxnXZSRDXEQT5Gxd83Km/WjqEPTuO2UN8d3XUPTYA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.5.0.tgz",
+      "integrity": "sha512-xSVa5AWblaRcVLxsxuQr1diGrQY2RWXFXTUvwg5sio1eHtKOqoDZi+FR92RSMKypIUDDCuH8JsU9OsoeW9W65g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -407,9 +407,9 @@
       }
     },
     "node_modules/@lvce-editor/process-explorer": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.8.0.tgz",
-      "integrity": "sha512-bSxbkJyJc9lhp2+uAqxX/X48NrZrNzt8TV0YcANdz73Iy+c6TFMx21VpDTuk3RPhLsZnLpsyrJB87fvoHNq/+Q==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.10.0.tgz",
+      "integrity": "sha512-9IKLMpNiY/ta3b6grUT0GecULtRYXL3gkpxA99opt3IHeAWZYtgixqz4WUry0dBQhl9QQ6rd/rPFJut4IsJnLw==",
       "license": "MIT",
       "bin": {
         "process-explorer": "bin/processExplorer.js"
@@ -422,9 +422,9 @@
       }
     },
     "node_modules/@lvce-editor/pty-host": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.2.0.tgz",
-      "integrity": "sha512-UQwF0lyV3B6DlL70nUl3GVg6eqZXIrUaUZvwnikW6ZnzPHqvqzXdZk4V0CgW32dnw3GHMkYdh0+95LhlRi+3tw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.3.0.tgz",
+      "integrity": "sha512-g2hTRb7lSc3uZaLq54dthlNG9ANG6eyJYPMih/WMqq+8GSoRblhbZZhsUpJdpaTb7hnwcsJ3y0LK5X8IKm2tDQ==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -461,13 +461,13 @@
       }
     },
     "node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.33.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.33.0.tgz",
-      "integrity": "sha512-R7idm97PKjafSXY0fVYl56tBIAAploTTPcloNt2+JIkRM2iy8awwIgg+aqajJ5CyM7N03Uig7dmKMRqtReZIxw==",
+      "version": "9.35.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.35.0.tgz",
+      "integrity": "sha512-ZdY4vLJ1RLCacxACY0AJ1nGQgHyZBLUmbuq5TuI0zzqaKXJh5f/SLEWRWUsnXtlSMg0hS/1uzLKKga3gO8svNg==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.18.0",
+        "@lvce-editor/constants": "^5.19.0",
         "@lvce-editor/rpc": "^6.4.0"
       }
     },
@@ -493,13 +493,13 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.87.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.87.3.tgz",
-      "integrity": "sha512-7DMmVOeYljeE4dwJyAQxUPstraJYLRybrmPUJj+VYrLAVT8yTgaqIQpoy+HCfY8Wq07gh7DijHD/glJ+4kjrlA==",
+      "version": "0.91.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.91.3.tgz",
+      "integrity": "sha512-suwzex/+z/ARr500fKOMezqwN1bXah14P1uks2tNGBInvGkIPsy7jS8DBY2BeZFlsLg/yQvFWzBrUlP3EULfbw==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.87.3",
-        "@lvce-editor/static-server": "0.87.3"
+        "@lvce-editor/shared-process": "0.91.3",
+        "@lvce-editor/static-server": "0.91.3"
       },
       "bin": {
         "server": "bin/server.js"
@@ -509,37 +509,38 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.87.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.87.3.tgz",
-      "integrity": "sha512-naAEhE+7/A1YVqL8m81eBGVXvXrWhdYYpicBbzAwB0QSkuJ/ZQtksRuj1ywvr3BPlR6bC7798Bmy8uLwfrtd4g==",
+      "version": "0.91.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.91.3.tgz",
+      "integrity": "sha512-tNbg1tvO9vAOy7XGAhk46T2tflczsK0v7YmQEp7UI+Ym5kR1S2bMqkynVY2qGaDcxinSRoRuBxAXKny7tV4Hew==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.7.0",
-        "@lvce-editor/auth-process": "1.8.0",
-        "@lvce-editor/extension-host-helper-process": "0.87.3",
+        "@lvce-editor/auth-process": "1.9.0",
+        "@lvce-editor/extension-host-helper-process": "0.91.3",
         "@lvce-editor/ipc": "16.3.0",
         "@lvce-editor/json-rpc": "8.2.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
         "@lvce-editor/pretty-error": "2.0.0",
-        "@lvce-editor/process-explorer": "3.8.0",
-        "@lvce-editor/rpc-registry": "9.33.0",
+        "@lvce-editor/process-explorer": "3.10.0",
+        "@lvce-editor/rpc-registry": "9.35.0",
         "@lvce-editor/verror": "1.7.0",
         "is-object": "^1.0.2",
+        "markdown-it": "^14.3.0",
         "xdg-basedir": "^5.1.0"
       },
       "engines": {
         "node": ">=24"
       },
       "optionalDependencies": {
-        "@lvce-editor/embeds-process": "4.9.0",
-        "@lvce-editor/file-system-process": "5.3.0",
-        "@lvce-editor/file-watcher-process": "4.2.0",
+        "@lvce-editor/embeds-process": "4.9.1",
+        "@lvce-editor/file-system-process": "5.4.0",
+        "@lvce-editor/file-watcher-process": "4.5.0",
         "@lvce-editor/network-process": "5.2.0",
         "@lvce-editor/preload": "1.5.0",
         "@lvce-editor/preview-process": "11.0.0",
-        "@lvce-editor/pty-host": "8.2.0",
+        "@lvce-editor/pty-host": "8.3.0",
         "@lvce-editor/search-process": "15.1.0",
-        "@lvce-editor/typescript-compile-process": "5.2.0",
+        "@lvce-editor/typescript-compile-process": "5.3.0",
         "open": "^11.0.0",
         "tail": "^2.2.6",
         "tmp-promise": "^3.0.3",
@@ -547,18 +548,18 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.87.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.87.3.tgz",
-      "integrity": "sha512-rXEChvFqrZrVI/cCfnQKphsr8LvbwxWETg5j4O0EiCN/MhiQuYvxHxN/LkYbUmsKe52OyBNnVc4MjHUTnXZiLA==",
+      "version": "0.91.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.91.3.tgz",
+      "integrity": "sha512-rCfA0jGuQ+owjbQJyyGcM7NyBUZu9XV3FxcTsVU0AwWZLYEBd7zo2mfD4dFIN/OQlD4Ao3q2m2G8s1dd7IUp3g==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
       }
     },
     "node_modules/@lvce-editor/typescript-compile-process": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.2.0.tgz",
-      "integrity": "sha512-M7A+P4+o/BX32diCV6pQlPNdG+xsXECL4HqWrvMHQHnhvl7k4OWBYSbOgKwBSTJMkTdWRELOi/l7Q0/rUDMHLQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.3.0.tgz",
+      "integrity": "sha512-0NlQK1Ck/Xanq8tcw+v9zlHc576EFFZ0jwxr8BWN5SY0c/G1f6gU8pirJBkW5mz2A1GfV9aj67P+NDk1iLUChg==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -974,6 +975,12 @@
         "node": ">=18.12"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -1360,6 +1367,18 @@
       "optional": true,
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/events-universal": {
@@ -1875,6 +1894,25 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/lowercase-keys": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-4.0.1.tgz",
@@ -1886,6 +1924,39 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -2294,6 +2365,15 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/queue-microtask": {
@@ -2710,6 +2790,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
     "node_modules/uint8array-extras": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
@@ -2780,9 +2866,9 @@
       "optional": true
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@lvce-editor/server": "^0.87.3"
+    "@lvce-editor/server": "^0.91.3"
   }
 }

--- a/packages/typescript-worker/src/parts/BraceCompletion/BraceCompletion.ts
+++ b/packages/typescript-worker/src/parts/BraceCompletion/BraceCompletion.ts
@@ -1,0 +1,12 @@
+import type { CommonRpc } from '../CommonRpc/CommonRpc.ts'
+import { provideBraceCompletion } from '../BraceCompletion2/BraceCompletion2.ts'
+
+export const provide = async (
+  typeScriptRpc: CommonRpc,
+  Position: any,
+  textDocument: any,
+  offset: number,
+  openingBrace: string,
+) => {
+  return provideBraceCompletion(textDocument, offset, openingBrace)
+}

--- a/packages/typescript-worker/src/parts/BraceCompletion2/BraceCompletion2.ts
+++ b/packages/typescript-worker/src/parts/BraceCompletion2/BraceCompletion2.ts
@@ -1,0 +1,12 @@
+import * as Assert from '../Assert/Assert.ts'
+import { getOrCreateLanguageService } from '../GetOrCreateLanguageService/GetOrCreateLanguageService.ts'
+
+export const provideBraceCompletion = (textDocument: any, offset: number, openingBrace: string): boolean => {
+  const uri = textDocument.uri
+  Assert.string(uri)
+  Assert.number(offset)
+  Assert.string(openingBrace)
+  const { languageService, fs } = getOrCreateLanguageService(uri)
+  fs.writeFile(uri, textDocument.text)
+  return languageService.isValidBraceCompletionAtPosition(uri, offset, openingBrace.charCodeAt(0))
+}

--- a/packages/typescript-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/typescript-worker/src/parts/CommandMap/CommandMap.ts
@@ -1,3 +1,4 @@
+import * as BraceCompletion from '../BraceCompletion/BraceCompletion.ts'
 import * as Comment from '../Comment/Comment.ts'
 import * as Completion from '../Completion/Completion.ts'
 import * as Definition from '../Definition/Definition.ts'
@@ -12,6 +13,7 @@ import * as Selection from '../Selection/Selection.ts'
 import * as WrapCommand from '../WrapCommand/WrapCommand.ts'
 
 export const commandMap = {
+  'BraceCompletion.provide': WrapCommand.wrapCommand(BraceCompletion.provide),
   'Comment.provide': WrapCommand.wrapCommand(Comment.provide),
   'Completion.getCompletions': WrapCommand.wrapCommand(Completion.getCompletion),
   'Completion.resolveCompletion': WrapCommand.wrapCommand(ResolveCompletion.resolveCompletion),

--- a/packages/typescript-worker/src/parts/TypeScriptLanguageHost/TypeScriptLanguageHost.ts
+++ b/packages/typescript-worker/src/parts/TypeScriptLanguageHost/TypeScriptLanguageHost.ts
@@ -74,7 +74,7 @@ export const create = (
     },
     getScriptFileNames() {
       const files = fileSystem.getScriptFileNames() as string[]
-      return files
+      return [...new Set([...options.fileNames, ...files])]
     },
     getScriptVersion(fileName) {
       return `${0}`
@@ -89,7 +89,7 @@ export const create = (
       throw new Error('not implemented')
     },
     getCurrentDirectory() {
-      return ''
+      return options.options.rootDir || ''
     },
     getDefaultLibFileName(options) {
       const defaultLibFileName = ts.getDefaultLibFileName(options)

--- a/packages/typescript-worker/test/BraceCompletion2.test.ts
+++ b/packages/typescript-worker/test/BraceCompletion2.test.ts
@@ -1,0 +1,30 @@
+import { expect, jest, test } from '@jest/globals'
+
+const writeFile = jest.fn()
+const isValidBraceCompletionAtPosition = jest.fn((_uri: string, _offset: number, _characterCode: number) => true)
+
+jest.unstable_mockModule('../src/parts/GetOrCreateLanguageService/GetOrCreateLanguageService.ts', () => ({
+  getOrCreateLanguageService() {
+    return {
+      fs: {
+        writeFile,
+      },
+      languageService: {
+        isValidBraceCompletionAtPosition,
+      },
+    }
+  },
+}))
+
+const { provideBraceCompletion } = await import('../src/parts/BraceCompletion2/BraceCompletion2.ts')
+
+test('provideBraceCompletion updates the document and checks the opening brace', () => {
+  const textDocument = {
+    text: 'win',
+    uri: 'memfs:///workspace/test.ts',
+  }
+
+  expect(provideBraceCompletion(textDocument, 3, '{')).toBe(true)
+  expect(writeFile).toHaveBeenCalledWith(textDocument.uri, textDocument.text)
+  expect(isValidBraceCompletionAtPosition).toHaveBeenCalledWith(textDocument.uri, 3, '{'.charCodeAt(0))
+})

--- a/packages/typescript-worker/test/TypeScriptLanguageHost.test.ts
+++ b/packages/typescript-worker/test/TypeScriptLanguageHost.test.ts
@@ -298,7 +298,7 @@ test('getProjectVersion should return string version', () => {
   expect(host.getProjectVersion?.()).toBe('0')
 })
 
-test('getScriptFileNames should return file system script names', () => {
+test('getScriptFileNames should return configured and file system script names', () => {
   globalThis.rpc = {
     invoke: jest.fn(() => Promise.resolve()),
   }
@@ -315,11 +315,11 @@ test('getScriptFileNames should return file system script names', () => {
     invokeSync: () => true,
   }
 
-  const mockOptions = { options: {}, fileNames: [], errors: [] }
+  const mockOptions = { options: {}, fileNames: ['configured.ts', 'file1.ts'], errors: [] }
 
   const host = create(TypeScript, mockFileSystem, mockSyncRpc, mockOptions)
 
-  expect(host.getScriptFileNames?.()).toEqual(['file1.ts', 'file2.ts'])
+  expect(host.getScriptFileNames?.()).toEqual(['configured.ts', 'file1.ts', 'file2.ts'])
 })
 
 test('getScriptVersion should return string version', () => {
@@ -429,7 +429,7 @@ test('getCustomTransformers should throw error', () => {
   }).toThrow('not implemented')
 })
 
-test('getCurrentDirectory should return empty string', () => {
+test('getCurrentDirectory should return configured root directory', () => {
   globalThis.rpc = {
     invoke: jest.fn(() => Promise.resolve()),
   }
@@ -446,11 +446,11 @@ test('getCurrentDirectory should return empty string', () => {
     invokeSync: () => true,
   }
 
-  const mockOptions = { options: {}, fileNames: [], errors: [] }
+  const mockOptions = { options: { rootDir: '/project' }, fileNames: [], errors: [] }
 
   const host = create(TypeScript, mockFileSystem, mockSyncRpc, mockOptions)
 
-  expect(host.getCurrentDirectory?.()).toBe('')
+  expect(host.getCurrentDirectory?.()).toBe('/project')
 })
 
 test('getDefaultLibFileName should return TypeScript default lib', () => {


### PR DESCRIPTION
## Summary
- enable auto-import, no-suggestions, and brace-completion E2E coverage
- include configured project files and root directory in the TypeScript language host so auto imports resolve
- register a TypeScript brace-completion provider backed by the language service
- complete the brace-completion fixture and regression test

## Validation
- npm run type-check
- npm test
- npm run build
- Prettier check for changed files
- full E2E run against the updated local editor worker: 29 completion/TypeScript scenarios pass, 12 unrelated scenarios remain skipped

Depends on the editor-worker brace-offset fix being released into the E2E server bundle.