### PR TITLE
fix: handle diagnostics without locations

### DIFF
--- a/packages/typescript-worker/src/parts/GetDiagnosticFromTsResult2/GetDiagnosticFromTsResult2.ts
+++ b/packages/typescript-worker/src/parts/GetDiagnosticFromTsResult2/GetDiagnosticFromTsResult2.ts
@@ -1,32 +1,67 @@
-import type ts from 'typescript'
 import * as GetDiagnosticSeverity from '../GetDiagnosticSeverity/GetDiagnosticSeverity.ts'
 import { getPositionAt } from '../GetPositionAt/GetPositionAt.ts'
+
+interface TypeScriptDiagnostic {
+  readonly category: number
+  readonly code: number
+  readonly file: { readonly fileName: string } | undefined
+  readonly length: number | undefined
+  readonly messageText: string
+  readonly start: number | undefined
+}
+
+interface TypeScriptDiagnosticWithLocation extends TypeScriptDiagnostic {
+  readonly file: { readonly fileName: string }
+  readonly length: number
+  readonly start: number
+}
+
+interface ConvertedDiagnostic {
+  readonly code: number
+  readonly columnIndex: number
+  readonly endColumnIndex: number
+  readonly endRowIndex: number
+  readonly message: string
+  readonly rowIndex: number
+  readonly source: 'ts'
+  readonly type: 'error' | 'warning'
+  readonly uri: string
+}
 
 /**
  *
  */
-const convertTsDiagnostic = (text: string, diagnostic: ts.DiagnosticWithLocation) => {
-  // TODO in api, use only startoffset and endoffset. problems view can convert locations if needed
+const convertTsDiagnostic = (text: string, diagnostic: TypeScriptDiagnosticWithLocation): ConvertedDiagnostic => {
+  // TODO in api, use only start offset and end offset. problems view can convert locations if needed
   const start = getPositionAt(text, diagnostic.start)
   const end = getPositionAt(text, diagnostic.start + diagnostic.length)
   return {
-    rowIndex: start.rowIndex - 1,
+    code: diagnostic.code,
     columnIndex: start.columnIndex - 1, // TODO should be offset based here
-    endRowIndex: end.rowIndex - 1,
     endColumnIndex: end.columnIndex - 1,
-
+    endRowIndex: end.rowIndex - 1,
     message: diagnostic.messageText,
+    rowIndex: start.rowIndex - 1,
+    source: 'ts',
     type: GetDiagnosticSeverity.getDiagnosticSeverity(diagnostic),
     uri: diagnostic.file.fileName,
-    source: 'ts',
-    code: diagnostic.code,
   }
 }
 
-export const getDiagnosticsFromTsResult2 = (text: string, tsResult: readonly ts.Diagnostic[]) => {
-  const diagnostics: any[] = []
+const hasLocation = (diagnostic: TypeScriptDiagnostic): diagnostic is TypeScriptDiagnosticWithLocation => {
+  return Boolean(diagnostic.file) && diagnostic.start !== undefined && diagnostic.length !== undefined
+}
+
+export const getDiagnosticsFromTsResult2 = (
+  text: string,
+  tsResult: readonly TypeScriptDiagnostic[],
+): readonly ConvertedDiagnostic[] => {
+  const diagnostics: ConvertedDiagnostic[] = []
   for (const tsDiagnostic of tsResult) {
-    diagnostics.push(convertTsDiagnostic(text, tsDiagnostic as any))
+    if (!hasLocation(tsDiagnostic)) {
+      continue
+    }
+    diagnostics.push(convertTsDiagnostic(text, tsDiagnostic))
   }
   return diagnostics
 }

--- a/packages/typescript-worker/test/GetDiagnosticFromTsResult2.test.ts
+++ b/packages/typescript-worker/test/GetDiagnosticFromTsResult2.test.ts
@@ -1,0 +1,47 @@
+import type ts from 'typescript'
+import { expect, test } from '@jest/globals'
+import { getDiagnosticsFromTsResult2 } from '../src/parts/GetDiagnosticFromTsResult2/GetDiagnosticFromTsResult2.ts'
+
+test('skips diagnostics without a source location', () => {
+  const diagnostics = [
+    {
+      category: 1,
+      code: 2318,
+      file: undefined,
+      length: undefined,
+      messageText: "Cannot find global type 'Array'.",
+      start: undefined,
+    },
+  ] as const
+
+  expect(getDiagnosticsFromTsResult2('const value = 1', diagnostics)).toEqual([])
+})
+
+test('converts diagnostics with a source location', () => {
+  const diagnostics = [
+    {
+      category: 1,
+      code: 2322,
+      file: {
+        fileName: '/test.ts',
+      } as ts.SourceFile,
+      length: 5,
+      messageText: "Type 'number' is not assignable to type 'string'.",
+      start: 6,
+    },
+  ] as const
+
+  expect(getDiagnosticsFromTsResult2('const value = 1', diagnostics)).toEqual([
+    {
+      code: 2322,
+      columnIndex: 5,
+      endColumnIndex: 10,
+      endRowIndex: -1,
+      message: "Type 'number' is not assignable to type 'string'.",
+      rowIndex: -1,
+      source: 'ts',
+      type: 'error',
+      uri: '/test.ts',
+    },
+  ])
+})


### PR DESCRIPTION
Skips TypeScript diagnostics without source locations before converting editor diagnostics, preventing undefined fileName access while preserving located diagnostics.