### PR TITLE
fix: resolve relative imports as file uris

### DIFF
--- a/packages/e2e/fixtures/diagnostics-relative-parent-import/package.json
+++ b/packages/e2e/fixtures/diagnostics-relative-parent-import/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "diagnostics-relative-parent-import",
+  "version": "1.0.0",
+  "type": "module"
+}

--- a/packages/e2e/fixtures/diagnostics-relative-parent-import/packages/editor-worker/src/something.ts
+++ b/packages/e2e/fixtures/diagnostics-relative-parent-import/packages/editor-worker/src/something.ts
@@ -1,0 +1,1 @@
+export const value = 1

--- a/packages/e2e/fixtures/diagnostics-relative-parent-import/packages/editor-worker/test/test.ts
+++ b/packages/e2e/fixtures/diagnostics-relative-parent-import/packages/editor-worker/test/test.ts
@@ -1,0 +1,3 @@
+import { value } from '../src/something.ts'
+
+const result: string = value

--- a/packages/e2e/fixtures/diagnostics-relative-parent-import/tsconfig.json
+++ b/packages/e2e/fixtures/diagnostics-relative-parent-import/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": [],
+    "module": "esnext",
+    "moduleResolution": "nodenext",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  }
+}

--- a/packages/e2e/src/typescript.diagnostics-relative-parent-import.ts
+++ b/packages/e2e/src/typescript.diagnostics-relative-parent-import.ts
@@ -1,0 +1,31 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-relative-parent-import'
+
+export const test: Test = async ({ Editor, FileSystem, Main, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics-relative-parent-import')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  const uri = `${workspaceUrl}/packages/editor-worker/test/test.ts`
+  await Main.openUri(uri)
+
+  // assert
+  const expectedDiagnostics = [
+    {
+      code: 2322,
+      columnIndex: 5,
+      endColumnIndex: 11,
+      endRowIndex: 1,
+      message: "Type 'number' is not assignable to type 'string'.",
+      rowIndex: 1,
+      source: 'ts',
+      type: 'error',
+      uri,
+    },
+  ] as const
+  await Editor.shouldHaveDiagnostics(expectedDiagnostics)
+}

--- a/packages/typescript-worker/src/parts/CreateModuleResolver/CreateModuleResolver.ts
+++ b/packages/typescript-worker/src/parts/CreateModuleResolver/CreateModuleResolver.ts
@@ -22,12 +22,30 @@ const isNode = (path: string): boolean => {
   return path.startsWith('node:')
 }
 
+const windowsAbsolutePathRegex = /^[a-zA-Z]:\//
+
+const toFileUri = (path: string): string => {
+  const normalizedPath = path.replaceAll('\\', '/')
+  if (normalizedPath.startsWith('file://')) {
+    return normalizedPath
+  }
+  if (normalizedPath.startsWith('/')) {
+    return `file://${normalizedPath}`
+  }
+  if (windowsAbsolutePathRegex.test(normalizedPath)) {
+    return `file:///${normalizedPath}`
+  }
+  return normalizedPath
+}
+
+const resolveRelativePath = (containingFile: string, text: string): string => {
+  const containingFileUri = toFileUri(containingFile)
+  return new URL(text, containingFileUri).href
+}
+
 const resolveModuleNameRelative = (containingFile: string, text: string): ResolvedModuleWithFailedLookupLocations => {
-  const dirname = getDirName(containingFile)
-  // @ts-ignore
-  const resolveFileName = joinPath(dirname, text)
+  const resolveFileName = resolveRelativePath(containingFile, text)
   const extension = getExtension(resolveFileName)
-  // TODO resolve relative path
   return {
     resolvedModule: {
       extension,

--- a/packages/typescript-worker/test/CreateModuleResolver.test.ts
+++ b/packages/typescript-worker/test/CreateModuleResolver.test.ts
@@ -68,7 +68,7 @@ test('createModuleResolver should handle relative imports starting with ./', () 
 
   expect(result.resolvedModule).toBeDefined()
   expect(result.resolvedModule?.extension).toBe('')
-  expect(result.resolvedModule?.resolvedFileName).toBe('/path/to/relative-module')
+  expect(result.resolvedModule?.resolvedFileName).toBe('file:///path/to/relative-module')
 })
 
 test('createModuleResolver should handle relative imports starting with ../', () => {
@@ -87,8 +87,60 @@ test('createModuleResolver should handle relative imports starting with ../', ()
   })
 
   expect(result.resolvedModule).toBeDefined()
-  expect(result.resolvedModule?.extension).toBe('./parent-module')
-  expect(result.resolvedModule?.resolvedFileName).toBe('/path/to/../parent-module')
+  expect(result.resolvedModule?.extension).toBe('')
+  expect(result.resolvedModule?.resolvedFileName).toBe('file:///path/parent-module')
+})
+
+test('createModuleResolver should normalize relative imports from file uris', () => {
+  globalThis.rpc = {
+    invoke: jest.fn(() => Promise.resolve()),
+  }
+
+  const mockSyncRpc = {
+    invokeSync: () => '',
+  }
+
+  const resolver = createModuleResolver(mockSyncRpc)
+
+  const result = resolver(
+    '../src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts',
+    'file:///workspace/editor-worker/packages/editor-worker/test/DomEventListenerFunctions.test.ts',
+    {
+      target: TypeScript.ScriptTarget.ES2020,
+    },
+  )
+
+  expect(result.resolvedModule).toBeDefined()
+  expect(result.resolvedModule?.extension).toBe('.ts')
+  expect(result.resolvedModule?.resolvedFileName).toBe(
+    'file:///workspace/editor-worker/packages/editor-worker/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts',
+  )
+})
+
+test('createModuleResolver should resolve relative imports from absolute file paths as file uris', () => {
+  globalThis.rpc = {
+    invoke: jest.fn(() => Promise.resolve()),
+  }
+
+  const mockSyncRpc = {
+    invokeSync: () => '',
+  }
+
+  const resolver = createModuleResolver(mockSyncRpc)
+
+  const result = resolver(
+    '../src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts',
+    '/workspace/editor-worker/packages/editor-worker/test/DomEventListenerFunctions.test.ts',
+    {
+      target: TypeScript.ScriptTarget.ES2020,
+    },
+  )
+
+  expect(result.resolvedModule).toBeDefined()
+  expect(result.resolvedModule?.extension).toBe('.ts')
+  expect(result.resolvedModule?.resolvedFileName).toBe(
+    'file:///workspace/editor-worker/packages/editor-worker/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts',
+  )
 })
 
 test('createModuleResolver should resolve node modules with package.json', () => {


### PR DESCRIPTION
## Summary
- resolve relative TypeScript imports through URL normalization so plain absolute paths become valid file URIs
- normalize parent directory imports like packages/editor-worker/test/../src to packages/editor-worker/src
- add unit coverage and an e2e diagnostics regression fixture for ../src imports from an editor-worker-shaped package

## Verification
- npm test -- CreateModuleResolver.test.ts
- npm run type-check
- npm run build
- npm run e2e:headless