### PR TITLE
feature: remove exports from extension entry point

### DIFF
--- a/packages/extension/src/languageFeaturesTypeScriptMain.ts
+++ b/packages/extension/src/languageFeaturesTypeScriptMain.ts
@@ -1,4 +1,3 @@
-export { activate, deactivate } from './parts/Activate/Activate.ts'
 import { activate } from './parts/Activate/Activate.ts'
 
 await activate()


### PR DESCRIPTION
Remove the obsolete extension entry-point exports now that TypeScript language features run in isolation. The main module now only activates the extension directly.