### PR TITLE
feature: add TypeScript diagnostic panel e2e tests

### DIFF
--- a/packages/e2e/fixtures/diagnostics/src/abstract-class.ts
+++ b/packages/e2e/fixtures/diagnostics/src/abstract-class.ts
@@ -1,0 +1,7 @@
+export const fixture = true
+
+abstract class Shape {
+  abstract area(): number
+}
+
+export const shape = new Shape()

--- a/packages/e2e/fixtures/diagnostics/src/argument-type.ts
+++ b/packages/e2e/fixtures/diagnostics/src/argument-type.ts
@@ -1,0 +1,5 @@
+export const fixture = true
+
+const takesNumber = (value: number): number => value
+
+export const result = takesNumber('one')

--- a/packages/e2e/fixtures/diagnostics/src/const-assignment.ts
+++ b/packages/e2e/fixtures/diagnostics/src/const-assignment.ts
@@ -1,0 +1,4 @@
+export const fixture = true
+
+const answer = 42
+answer = 43

--- a/packages/e2e/fixtures/diagnostics/src/excess-property.ts
+++ b/packages/e2e/fixtures/diagnostics/src/excess-property.ts
@@ -1,0 +1,10 @@
+export const fixture = true
+
+interface Options {
+  enabled: boolean
+}
+
+export const options: Options = {
+  enabled: true,
+  color: 'blue',
+}

--- a/packages/e2e/fixtures/diagnostics/src/generic-constraint.ts
+++ b/packages/e2e/fixtures/diagnostics/src/generic-constraint.ts
@@ -1,0 +1,7 @@
+export const fixture = true
+
+type NumericValue<T extends number> = {
+  value: T
+}
+
+export const value: NumericValue<string> = { value: 'one' }

--- a/packages/e2e/fixtures/diagnostics/src/missing-argument.ts
+++ b/packages/e2e/fixtures/diagnostics/src/missing-argument.ts
@@ -1,0 +1,5 @@
+export const fixture = true
+
+const add = (left: number, right: number): number => left + right
+
+export const result = add(1)

--- a/packages/e2e/fixtures/diagnostics/src/missing-property-access.ts
+++ b/packages/e2e/fixtures/diagnostics/src/missing-property-access.ts
@@ -1,0 +1,7 @@
+export const fixture = true
+
+const user = {
+  name: 'Ada',
+}
+
+export const age = user.age

--- a/packages/e2e/fixtures/diagnostics/src/private-property.ts
+++ b/packages/e2e/fixtures/diagnostics/src/private-property.ts
@@ -1,0 +1,8 @@
+export const fixture = true
+
+class Account {
+  private balance = 0
+}
+
+const account = new Account()
+export const balance = account.balance

--- a/packages/e2e/fixtures/diagnostics/src/readonly-property.ts
+++ b/packages/e2e/fixtures/diagnostics/src/readonly-property.ts
@@ -1,0 +1,8 @@
+export const fixture = true
+
+interface User {
+  readonly id: number
+}
+
+const user: User = { id: 1 }
+user.id = 2

--- a/packages/e2e/fixtures/diagnostics/src/tuple-index.ts
+++ b/packages/e2e/fixtures/diagnostics/src/tuple-index.ts
@@ -1,0 +1,5 @@
+export const fixture = true
+
+const pair: [string, number] = ['one', 2]
+
+export const third = pair[2]

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-abstract-class.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-abstract-class.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-abstract-class'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/abstract-class.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('Cannot create an instance of an abstract class.')
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-argument-type.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-argument-type.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-argument-type'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/argument-type.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText(`Argument of type 'string' is not assignable to parameter of type 'number'.`)
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-const-assignment.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-const-assignment.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-const-assignment'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/const-assignment.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText(`Cannot assign to 'answer' because it is a constant.`)
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-excess-property.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-excess-property.ts
@@ -1,0 +1,25 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-excess-property'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/excess-property.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText(
+    `Object literal may only specify known properties, and 'color' does not exist in type 'Options'.`,
+  )
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-generic-constraint.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-generic-constraint.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-generic-constraint'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/generic-constraint.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText(`Type 'string' does not satisfy the constraint 'number'.`)
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-missing-argument.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-missing-argument.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-missing-argument'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/missing-argument.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('Expected 2 arguments, but got 1.')
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-missing-property-access.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-missing-property-access.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-missing-property-access'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/missing-property-access.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText(`Property 'age' does not exist on type '{ name: string; }'.`)
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-private-property.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-private-property.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-private-property'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/private-property.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText(`Property 'balance' is private and only accessible within class 'Account'.`)
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-readonly-property.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-readonly-property.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-readonly-property'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/readonly-property.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText(`Cannot assign to 'id' because it is a read-only property.`)
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-tuple-index.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-tuple-index.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-tuple-index'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/tuple-index.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText(`Tuple type '[string, number]' of length '2' has no element at index '2'.`)
+}


### PR DESCRIPTION
Adds ten Problems panel e2e scenarios covering distinct TypeScript errors and verifies the diagnostic messages shown to users.