### PR TITLE
fix: resolve declaration imports in node modules

### DIFF
--- a/packages/e2e/fixtures/completion-node-module-dts-relative-import/node_modules/abc/index.d.ts
+++ b/packages/e2e/fixtures/completion-node-module-dts-relative-import/node_modules/abc/index.d.ts
@@ -1,0 +1,1 @@
+export { activate } from './parts/Activation/Activation.ts'

--- a/packages/e2e/fixtures/completion-node-module-dts-relative-import/node_modules/abc/package.json
+++ b/packages/e2e/fixtures/completion-node-module-dts-relative-import/node_modules/abc/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "abc",
+  "version": "1.0.0",
+  "type": "module",
+  "types": "index.d.ts"
+}

--- a/packages/e2e/fixtures/completion-node-module-dts-relative-import/node_modules/abc/parts/Activation/Activation.d.ts
+++ b/packages/e2e/fixtures/completion-node-module-dts-relative-import/node_modules/abc/parts/Activation/Activation.d.ts
@@ -1,0 +1,3 @@
+export declare const activate: () => {
+  dispose(): void
+}

--- a/packages/e2e/fixtures/completion-node-module-dts-relative-import/package.json
+++ b/packages/e2e/fixtures/completion-node-module-dts-relative-import/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "completion-node-module-dts-relative-import",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "abc": "^1.0.0"
+  }
+}

--- a/packages/e2e/fixtures/completion-node-module-dts-relative-import/src/test.ts
+++ b/packages/e2e/fixtures/completion-node-module-dts-relative-import/src/test.ts
@@ -1,0 +1,3 @@
+import { activate } from 'abc'
+
+activate().dispose

--- a/packages/e2e/fixtures/completion-node-module-dts-relative-import/tsconfig.json
+++ b/packages/e2e/fixtures/completion-node-module-dts-relative-import/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": [],
+    "allowImportingTsExtensions": true,
+    "rootDir": ".",
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src"]
+}

--- a/packages/e2e/src/typescript.completion-node-module-dts-relative-import.ts
+++ b/packages/e2e/src/typescript.completion-node-module-dts-relative-import.ts
@@ -1,0 +1,22 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.completion-node-module-dts-relative-import'
+
+export const test: Test = async ({ FileSystem, Workspace, Main, Editor, Locator, expect }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/completion-node-module-dts-relative-import')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Main.openUri(`${workspaceUrl}/src/test.ts`)
+  await Editor.setCursor(2, 11)
+
+  // act
+  await Editor.openCompletion()
+
+  // assert
+  const completions = Locator('#Completions')
+  await expect(completions).toBeVisible()
+  const completionItems = completions.locator('.EditorCompletionItem')
+  await expect(completionItems).toHaveCount(1)
+  await expect(completionItems.nth(0)).toHaveText('dispose')
+}

--- a/packages/typescript-worker/src/parts/CreateModuleResolver/CreateModuleResolver.ts
+++ b/packages/typescript-worker/src/parts/CreateModuleResolver/CreateModuleResolver.ts
@@ -11,6 +11,9 @@ const getDirName = (path: string): string => {
 }
 
 const getExtension = (fileName: string): string => {
+  if (fileName.endsWith('.d.ts')) {
+    return '.d.ts'
+  }
   const dotIndex = fileName.lastIndexOf('.')
   if (dotIndex === -1) {
     return ''
@@ -43,8 +46,24 @@ const resolveRelativePath = (containingFile: string, text: string): string => {
   return new URL(text, containingFileUri).href
 }
 
+const getRelativeModuleName = (containingFile: string, text: string): string => {
+  const normalizedContainingFile = containingFile.replaceAll('\\', '/')
+  const isInNodeModules =
+    normalizedContainingFile.startsWith('node_modules/') || normalizedContainingFile.includes('/node_modules/')
+  if (
+    isInNodeModules &&
+    normalizedContainingFile.endsWith('.d.ts') &&
+    text.endsWith('.ts') &&
+    !text.endsWith('.d.ts')
+  ) {
+    return `${text.slice(0, -3)}.d.ts`
+  }
+  return text
+}
+
 const resolveModuleNameRelative = (containingFile: string, text: string): ResolvedModuleWithFailedLookupLocations => {
-  const resolveFileName = resolveRelativePath(containingFile, text)
+  const relativeModuleName = getRelativeModuleName(containingFile, text)
+  const resolveFileName = resolveRelativePath(containingFile, relativeModuleName)
   const extension = getExtension(resolveFileName)
   return {
     resolvedModule: {

--- a/packages/typescript-worker/test/CreateModuleResolver.test.ts
+++ b/packages/typescript-worker/test/CreateModuleResolver.test.ts
@@ -143,6 +143,48 @@ test('createModuleResolver should resolve relative imports from absolute file pa
   )
 })
 
+test('createModuleResolver should resolve .ts imports from declaration files in node_modules as .d.ts files', () => {
+  const resolver = createModuleResolver({
+    invokeSync: () => '',
+  })
+
+  const result = resolver('./parts/Activation/Activation.ts', '/project/node_modules/abc/index.d.ts', {
+    target: TypeScript.ScriptTarget.ES2020,
+  })
+
+  expect(result.resolvedModule).toBeDefined()
+  expect(result.resolvedModule?.extension).toBe('.d.ts')
+  expect(result.resolvedModule?.resolvedFileName).toBe(
+    'file:///project/node_modules/abc/parts/Activation/Activation.d.ts',
+  )
+})
+
+test('createModuleResolver should preserve .d.ts imports from declaration files in node_modules', () => {
+  const resolver = createModuleResolver({
+    invokeSync: () => '',
+  })
+
+  const result = resolver('./parts/Activation/Activation.d.ts', '/project/node_modules/abc/index.d.ts', {
+    target: TypeScript.ScriptTarget.ES2020,
+  })
+
+  expect(result.resolvedModule?.resolvedFileName).toBe(
+    'file:///project/node_modules/abc/parts/Activation/Activation.d.ts',
+  )
+})
+
+test('createModuleResolver should preserve .ts imports outside node_modules', () => {
+  const resolver = createModuleResolver({
+    invokeSync: () => '',
+  })
+
+  const result = resolver('./parts/Activation/Activation.ts', '/project/src/index.d.ts', {
+    target: TypeScript.ScriptTarget.ES2020,
+  })
+
+  expect(result.resolvedModule?.resolvedFileName).toBe('file:///project/src/parts/Activation/Activation.ts')
+})
+
 test('createModuleResolver should resolve node modules with package.json', () => {
   globalThis.rpc = {
     invoke: jest.fn(() => Promise.resolve()),


### PR DESCRIPTION
Summary:
- resolve relative `.ts` specifiers from declaration files under `node_modules` to the corresponding `.d.ts` file
- add unit coverage for the scoped fallback and an e2e completion regression matching the package re-export scenario