### PR TITLE
feature: name TypeScript language features worker

### DIFF
--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -1,6 +1,7 @@
 {
   "id": "builtin.language-features-typescript",
   "name": "Language Features TypeScript",
+  "workerName": "TypeScript Language Features Worker",
   "description": "TypeScript Language Support",
   "browser": "dist/languageFeaturesTypeScriptMain.js",
   "isolated": true,


### PR DESCRIPTION
Adds a human-readable worker name for the isolated TypeScript language-features extension so browser tooling displays `TypeScript Language Features Worker` instead of the extension API fallback identifier.