### PR TITLE
fix: format nested diagnostic messages

### DIFF
--- a/packages/e2e/fixtures/diagnostics-message-chain/package.json
+++ b/packages/e2e/fixtures/diagnostics-message-chain/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "diagnostics-message-chain",
+  "version": "1.0.0",
+  "type": "module"
+}

--- a/packages/e2e/fixtures/diagnostics-message-chain/src/index.ts
+++ b/packages/e2e/fixtures/diagnostics-message-chain/src/index.ts
@@ -1,0 +1,6 @@
+const state = {
+  extensions: [],
+}
+const index: number = 0
+
+export const extension = state[index]

--- a/packages/e2e/fixtures/diagnostics-message-chain/tsconfig.json
+++ b/packages/e2e/fixtures/diagnostics-message-chain/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-message-chain.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-message-chain.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-message-chain'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics-message-chain')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  await Main.openUri(`${workspaceUrl}/src/index.ts`)
+
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const label = problems.nth(1).locator('.Label')
+  await expect(label).toHaveText(
+    "Element implicitly has an 'any' type because expression of type 'number' can't be used to index type '{ extensions: never[]; }'.\n  No index signature with a parameter of type 'number' was found on type '{ extensions: never[]; }'.",
+  )
+}

--- a/packages/typescript-worker/src/parts/GetDiagnosticFromTsResult2/GetDiagnosticFromTsResult2.ts
+++ b/packages/typescript-worker/src/parts/GetDiagnosticFromTsResult2/GetDiagnosticFromTsResult2.ts
@@ -1,12 +1,17 @@
 import * as GetDiagnosticSeverity from '../GetDiagnosticSeverity/GetDiagnosticSeverity.ts'
 import { getPositionAt } from '../GetPositionAt/GetPositionAt.ts'
 
+interface TypeScriptDiagnosticMessageChain {
+  readonly messageText: string
+  readonly next?: readonly TypeScriptDiagnosticMessageChain[]
+}
+
 interface TypeScriptDiagnostic {
   readonly category: number
   readonly code: number
   readonly file: { readonly fileName: string } | undefined
   readonly length: number | undefined
-  readonly messageText: string
+  readonly messageText: string | TypeScriptDiagnosticMessageChain
   readonly start: number | undefined
 }
 
@@ -28,6 +33,22 @@ interface ConvertedDiagnostic {
   readonly uri: string
 }
 
+const flattenDiagnosticMessageText = (
+  messageText: string | TypeScriptDiagnosticMessageChain,
+  indentation = 0,
+): string => {
+  if (typeof messageText === 'string') {
+    return messageText
+  }
+  const prefix = indentation === 0 ? '' : `\n${'  '.repeat(indentation)}`
+  let result = `${prefix}${messageText.messageText}`
+  const children = messageText.next || []
+  for (const child of children) {
+    result += flattenDiagnosticMessageText(child, indentation + 1)
+  }
+  return result
+}
+
 /**
  *
  */
@@ -40,7 +61,7 @@ const convertTsDiagnostic = (text: string, diagnostic: TypeScriptDiagnosticWithL
     columnIndex: start.columnIndex,
     endColumnIndex: end.columnIndex,
     endRowIndex: end.rowIndex,
-    message: diagnostic.messageText,
+    message: flattenDiagnosticMessageText(diagnostic.messageText),
     rowIndex: start.rowIndex,
     source: 'ts',
     type: GetDiagnosticSeverity.getDiagnosticSeverity(diagnostic),

--- a/packages/typescript-worker/test/GetDiagnosticFromTsResult2.test.ts
+++ b/packages/typescript-worker/test/GetDiagnosticFromTsResult2.test.ts
@@ -45,3 +45,45 @@ test('converts diagnostics with a source location', () => {
     },
   ])
 })
+
+test('flattens diagnostic message chains', () => {
+  const diagnostics = [
+    {
+      category: 1,
+      code: 7053,
+      file: {
+        fileName: '/test.ts',
+      } as ts.SourceFile,
+      length: 5,
+      messageText: {
+        category: 1,
+        code: 7053,
+        messageText:
+          "Element implicitly has an 'any' type because expression of type 'number' can't be used to index type 'State'.",
+        next: [
+          {
+            category: 1,
+            code: 7053,
+            messageText: "No index signature with a parameter of type 'number' was found on type 'State'.",
+          },
+        ],
+      },
+      start: 6,
+    },
+  ] as const
+
+  expect(getDiagnosticsFromTsResult2('const value = 1', diagnostics)).toEqual([
+    {
+      code: 7053,
+      columnIndex: 6,
+      endColumnIndex: 11,
+      endRowIndex: 0,
+      message:
+        "Element implicitly has an 'any' type because expression of type 'number' can't be used to index type 'State'.\n  No index signature with a parameter of type 'number' was found on type 'State'.",
+      rowIndex: 0,
+      source: 'ts',
+      type: 'error',
+      uri: '/test.ts',
+    },
+  ])
+})


### PR DESCRIPTION
## Summary
- accept TypeScript diagnostic message chains in the worker adapter
- flatten nested messages using TypeScript-compatible newlines and indentation
- add a TS7053 Problems-panel regression that verifies the full message instead of an object string

## Verification
- npm run type-check -- --pretty false
- npm test -- --runInBand (205 worker tests passed)
- npm run build
- npm run build:static
- focused Problems-panel message-chain e2e
- targeted ESLint and Prettier checks