### PR TITLE
fix: resolve extensionless declaration imports

### DIFF
--- a/packages/e2e/fixtures/diagnostics-hoisted-node-modules/node_modules/@lvce-editor/rpc-registry/dist/dispatcher.d.ts
+++ b/packages/e2e/fixtures/diagnostics-hoisted-node-modules/node_modules/@lvce-editor/rpc-registry/dist/dispatcher.d.ts
@@ -1,0 +1,3 @@
+export interface Dispatcher {
+  readonly name: string
+}

--- a/packages/e2e/fixtures/diagnostics-hoisted-node-modules/node_modules/@lvce-editor/rpc-registry/dist/index.d.ts
+++ b/packages/e2e/fixtures/diagnostics-hoisted-node-modules/node_modules/@lvce-editor/rpc-registry/dist/index.d.ts
@@ -1,1 +1,1 @@
-export {}
+export { Dispatcher } from './dispatcher'

--- a/packages/typescript-worker/src/parts/CreateModuleResolver/CreateModuleResolver.ts
+++ b/packages/typescript-worker/src/parts/CreateModuleResolver/CreateModuleResolver.ts
@@ -48,13 +48,13 @@ const getRelativeModuleName = (containingFile: string, text: string): string => 
   const normalizedContainingFile = containingFile.replaceAll('\\', '/')
   const isInNodeModules =
     normalizedContainingFile.startsWith('node_modules/') || normalizedContainingFile.includes('/node_modules/')
-  if (
-    isInNodeModules &&
-    normalizedContainingFile.endsWith('.d.ts') &&
-    text.endsWith('.ts') &&
-    !text.endsWith('.d.ts')
-  ) {
+  const isDeclarationFile = normalizedContainingFile.endsWith('.d.ts')
+  if (isInNodeModules && isDeclarationFile && text.endsWith('.ts') && !text.endsWith('.d.ts')) {
     return `${text.slice(0, -3)}.d.ts`
+  }
+  const baseName = text.slice(text.lastIndexOf('/') + 1)
+  if (isInNodeModules && isDeclarationFile && !baseName.includes('.')) {
+    return `${text}.d.ts`
   }
   return text
 }

--- a/packages/typescript-worker/test/CreateModuleResolver.test.ts
+++ b/packages/typescript-worker/test/CreateModuleResolver.test.ts
@@ -159,6 +159,20 @@ test('createModuleResolver should resolve .ts imports from declaration files in 
   )
 })
 
+test('createModuleResolver should resolve extensionless imports from declaration files in node_modules as .d.ts files', () => {
+  const resolver = createModuleResolver({
+    invokeSync: () => '',
+  })
+
+  const result = resolver('./dispatcher', '/project/node_modules/undici-types/index.d.ts', {
+    target: TypeScript.ScriptTarget.ES2020,
+  })
+
+  expect(result.resolvedModule).toBeDefined()
+  expect(result.resolvedModule?.extension).toBe('.d.ts')
+  expect(result.resolvedModule?.resolvedFileName).toBe('file:///project/node_modules/undici-types/dispatcher.d.ts')
+})
+
 test('createModuleResolver should preserve .d.ts imports from declaration files in node_modules', () => {
   const resolver = createModuleResolver({
     invokeSync: () => '',


### PR DESCRIPTION
Summary:
- resolve extensionless relative imports in node_modules declaration files to their .d.ts targets
- cover the undici-types pattern in unit and hoisted-node-modules e2e fixtures