### PR TITLE
fix: include schemas in extension package

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -4,7 +4,25 @@
   "description": "",
   "type": "module",
   "main": "index.ts",
-  "scripts": {},
+  "scripts": {
+    "test": "node --unhandled-rejections=warn --experimental-vm-modules ../../node_modules/jest/bin/jest.js --bail --detectOpenHandles --forceExit"
+  },
+  "jest": {
+    "extensionsToTreatAsEsm": [
+      ".ts"
+    ],
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
+    },
+    "transform": {
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "useESM": true
+        }
+      ]
+    }
+  },
   "keywords": [],
   "author": "",
   "license": "MIT",

--- a/packages/build/src/build.ts
+++ b/packages/build/src/build.ts
@@ -2,6 +2,7 @@ import { bundleJs, packageExtension, replace } from '@lvce-editor/package-extens
 import { copyFile, cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import path, { join } from 'path'
 import { bundleExtensionJs } from './bundleExtensionJs.ts'
+import { copyExtensionSchemas } from './copyExtensionSchemas.ts'
 import { removeUnusedTypeScriptFiles } from './removeUnusedTypeScriptFIles.ts'
 import { root } from './root.ts'
 
@@ -41,6 +42,7 @@ await copyFile(join(root, 'README.md'), join(dist, 'README.md'))
 await copyFile(join(extension, 'extension.json'), join(dist, 'extension.json'))
 await mkdir(join(dist, 'media'), { recursive: true })
 await copyFile(join(extension, 'media', 'icon.png'), join(dist, 'media', 'icon.png'))
+await copyExtensionSchemas(extension, dist)
 
 await cp(join(root, 'node_modules', 'typescript'), join(dist, 'typescript'), {
   recursive: true,

--- a/packages/build/src/copyExtensionSchemas.ts
+++ b/packages/build/src/copyExtensionSchemas.ts
@@ -1,0 +1,8 @@
+import { cp } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export const copyExtensionSchemas = async (extensionPath: string, distPath: string): Promise<void> => {
+  await cp(join(extensionPath, 'schemas'), join(distPath, 'schemas'), {
+    recursive: true,
+  })
+}

--- a/packages/build/test/copyExtensionSchemas.test.ts
+++ b/packages/build/test/copyExtensionSchemas.test.ts
@@ -1,0 +1,31 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, test } from '@jest/globals'
+import { copyExtensionSchemas } from '../src/copyExtensionSchemas.ts'
+
+test('copyExtensionSchemas copies every schema into the packaged extension', async () => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), 'language-features-typescript-build-'))
+  const extensionPath = join(temporaryDirectory, 'extension')
+  const distPath = join(temporaryDirectory, 'dist')
+  const schemas = {
+    'jsconfig.schema.json': '{"title":"jsconfig"}',
+    'package.schema.json': '{"title":"package"}',
+    'tsconfig.schema.json': '{"title":"tsconfig"}',
+  }
+
+  try {
+    await mkdir(join(extensionPath, 'schemas'), { recursive: true })
+    await Promise.all(
+      Object.entries(schemas).map(([name, content]) => writeFile(join(extensionPath, 'schemas', name), content)),
+    )
+
+    await copyExtensionSchemas(extensionPath, distPath)
+
+    await expect(
+      Promise.all(Object.keys(schemas).map((name) => readFile(join(distPath, 'schemas', name), 'utf8'))),
+    ).resolves.toEqual(Object.values(schemas))
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Copies the TypeScript extension schema directory into release archives so extension-detail schema links resolve correctly.