### PR TITLE
fix: normalize TypeScript file paths

### DIFF
--- a/packages/extension/src/parts/Command/Command.ts
+++ b/packages/extension/src/parts/Command/Command.ts
@@ -2,6 +2,7 @@ import { readDirWithFileTypes, readFile as readFileApi } from '@lvce-editor/api'
 import * as Rpc from '../Rpc/Rpc.ts'
 import * as SyncApi from '../SyncApi/SyncApi.ts'
 import * as TextDocument from '../TextDocument/TextDocument.ts'
+import { toFileUri } from '../ToFileUri/ToFileUri.ts'
 
 const rpcInvoke = (method: string, ...params: any[]): any => {
   return Rpc.invoke(method, ...params)
@@ -18,11 +19,11 @@ const getPosition = (textDocument: any, offset: any): any => {
 }
 
 const readFile = (uri: any): any => {
-  return readFileApi(uri)
+  return readFileApi(toFileUri(uri))
 }
 
 const readDir = (uri: any): any => {
-  return readDirWithFileTypes(uri)
+  return readDirWithFileTypes(toFileUri(uri))
 }
 
 export const commandMap = {

--- a/packages/extension/src/parts/SyncApi/SyncApi.ts
+++ b/packages/extension/src/parts/SyncApi/SyncApi.ts
@@ -1,5 +1,6 @@
 import { exists as existsApi, readDirWithFileTypes, readFile } from '@lvce-editor/api'
 import * as SyncSetupState from '../SyncSetupState/SyncSetupState.ts'
+import { toFileUri } from '../ToFileUri/ToFileUri.ts'
 import { writeResult } from '../WriteResult/WriteResult.ts'
 
 export const syncSetup = async (
@@ -37,14 +38,14 @@ export const syncSetup = async (
 
 export const readFileSync = async (id: number, uri: string): Promise<void> => {
   const resultGenerator = () => {
-    return readFile(uri)
+    return readFile(toFileUri(uri))
   }
   await writeResult(id, resultGenerator)
 }
 
 export const readDirSync = async (id: number, uri: string): Promise<void> => {
   const resultGenerator = async () => {
-    const result = await readDirWithFileTypes(uri)
+    const result = await readDirWithFileTypes(toFileUri(uri))
     const baseNames = result.map((item) => item.name)
     return baseNames
   }
@@ -54,7 +55,7 @@ export const readDirSync = async (id: number, uri: string): Promise<void> => {
 export const exists = async (id: number, uri: string): Promise<void> => {
   const resultGenerator = async () => {
     try {
-      const result = await existsApi(uri)
+      const result = await existsApi(toFileUri(uri))
       return result
     } catch {
       return true

--- a/packages/extension/src/parts/ToFileUri/ToFileUri.ts
+++ b/packages/extension/src/parts/ToFileUri/ToFileUri.ts
@@ -1,0 +1,15 @@
+const windowsAbsolutePathRegex = /^[a-zA-Z]:\//
+
+export const toFileUri = (path: string): string => {
+  const normalizedPath = path.replaceAll('\\', '/')
+  if (normalizedPath.startsWith('//')) {
+    return `file:${normalizedPath}`
+  }
+  if (normalizedPath.startsWith('/')) {
+    return `file://${normalizedPath}`
+  }
+  if (windowsAbsolutePathRegex.test(normalizedPath)) {
+    return `file:///${normalizedPath}`
+  }
+  return normalizedPath
+}

--- a/packages/extension/test/ToFileUri.test.ts
+++ b/packages/extension/test/ToFileUri.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@jest/globals'
+import { toFileUri } from '../src/parts/ToFileUri/ToFileUri.ts'
+
+test('converts an absolute posix path to a file uri', () => {
+  expect(toFileUri('/home/user/project/tsconfig.json')).toBe('file:///home/user/project/tsconfig.json')
+})
+
+test('converts an absolute windows path to a file uri', () => {
+  expect(toFileUri('C:\\Users\\user\\project\\tsconfig.json')).toBe('file:///C:/Users/user/project/tsconfig.json')
+})
+
+test('converts a windows network path to a file uri', () => {
+  expect(toFileUri('\\\\server\\share\\project\\tsconfig.json')).toBe('file://server/share/project/tsconfig.json')
+})
+
+test('preserves an existing file uri', () => {
+  expect(toFileUri('file:///home/user/project/tsconfig.json')).toBe('file:///home/user/project/tsconfig.json')
+})
+
+test('preserves other uris', () => {
+  expect(toFileUri('memfs:///project/tsconfig.json')).toBe('memfs:///project/tsconfig.json')
+})
+
+test('preserves relative paths', () => {
+  expect(toFileUri('project/tsconfig.json')).toBe('project/tsconfig.json')
+})


### PR DESCRIPTION
Normalize native TypeScript filesystem paths to file URIs before forwarding them to the extension filesystem API. This prevents tsconfig and module reads from failing with `path must be a valid file uri`.