### PR TITLE
fix: refresh TypeScript projects for web diagnostics

### DIFF
--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -5,7 +5,7 @@
   "description": "TypeScript Language Support",
   "browser": "dist/languageFeaturesTypeScriptMain.js",
   "isolated": true,
-  "contentSecurityPolicy": ["default-src 'none'", "script-src 'self'"],
+  "contentSecurityPolicy": ["default-src 'none'", "script-src 'self'", "connect-src 'self'"],
   "repository": "https://github.com/lvce-editor/language-features-typescript",
   "icon": "media/icon.png",
   "activation": [

--- a/packages/typescript-worker/src/parts/CreateFileSystem/CreateFileSystem.ts
+++ b/packages/typescript-worker/src/parts/CreateFileSystem/CreateFileSystem.ts
@@ -2,21 +2,28 @@ import type { IFileSystem } from '../IFileSystem/IFileSystem.ts'
 
 export const createFileSystem = (): IFileSystem => {
   const files: Record<string, string> = Object.create(null)
+  const versions: Record<string, number> = Object.create(null)
+  let version = 0
   const fileSystem: IFileSystem = {
     getScriptFileNames() {
       return Object.keys(files)
     },
     getScriptVersion(uri) {
-      return '0'
+      return (versions[uri] || 0).toString()
     },
     getVersion() {
-      return '0'
+      return version.toString()
     },
     readFile(uri) {
       return files[uri]
     },
     writeFile(uri, content) {
+      if (files[uri] === content) {
+        return
+      }
       files[uri] = content
+      versions[uri] = (versions[uri] || 0) + 1
+      version++
     },
   }
   return fileSystem

--- a/packages/typescript-worker/src/parts/EmptyTsConfig/EmptyTsConfig.ts
+++ b/packages/typescript-worker/src/parts/EmptyTsConfig/EmptyTsConfig.ts
@@ -3,5 +3,8 @@ import type { ParsedCommandLine } from 'typescript'
 export const emptyTsconfig: ParsedCommandLine = {
   errors: [],
   fileNames: [],
-  options: {},
+  options: {
+    allowJs: true,
+    checkJs: true,
+  },
 }

--- a/packages/typescript-worker/src/parts/ResolveTsconfig/ResolveTsconfig.ts
+++ b/packages/typescript-worker/src/parts/ResolveTsconfig/ResolveTsconfig.ts
@@ -23,7 +23,7 @@ export const resolveTsconfig = (
       readFile,
       useCaseSensitiveFileNames: false,
     }
-    const existingOptions = {}
+    const existingOptions = emptyTsconfig.options
     const config2 = ts.parseJsonConfigFileContent(parsed, host, rootDir, existingOptions, tsconfigPath)
     let { options } = config2
     options = {

--- a/packages/typescript-worker/src/parts/TypeScriptLanguageHost/TypeScriptLanguageHost.ts
+++ b/packages/typescript-worker/src/parts/TypeScriptLanguageHost/TypeScriptLanguageHost.ts
@@ -72,7 +72,7 @@ export const create = (
       return []
     },
     getProjectVersion() {
-      return '0'
+      return fileSystem.getVersion()
     },
     getScriptFileNames() {
       const files = fileSystem.getScriptFileNames() as string[]
@@ -97,7 +97,7 @@ export const create = (
       return snapshot
     },
     getScriptVersion(fileName) {
-      return '0'
+      return fileSystem.getScriptVersion(fileName)
     },
     readDirectory(path, extensions, exclude, include, depth) {
       const dirents = syncRpc.invokeSync('SyncApi.readDirSync', path)

--- a/packages/typescript-worker/test/CreateFileSystem.test.ts
+++ b/packages/typescript-worker/test/CreateFileSystem.test.ts
@@ -59,17 +59,33 @@ test('createFileSystem should return empty array when no files', () => {
   expect(fileNames).toEqual([])
 })
 
-test('createFileSystem should return version string', () => {
+test('createFileSystem should update version when files change', () => {
   const fileSystem = createFileSystem()
 
   expect(fileSystem.getVersion()).toBe('0')
+  fileSystem.writeFile('file.ts', 'content')
+  expect(fileSystem.getVersion()).toBe('1')
+  fileSystem.writeFile('file.ts', 'updated content')
+  expect(fileSystem.getVersion()).toBe('2')
 })
 
-test('createFileSystem should return script version string', () => {
+test('createFileSystem should update script version when a file changes', () => {
   const fileSystem = createFileSystem()
 
   fileSystem.writeFile('file.ts', 'content')
-  expect(fileSystem.getScriptVersion('file.ts')).toBe('0')
+  expect(fileSystem.getScriptVersion('file.ts')).toBe('1')
+  fileSystem.writeFile('file.ts', 'updated content')
+  expect(fileSystem.getScriptVersion('file.ts')).toBe('2')
+})
+
+test('createFileSystem should preserve versions when content is unchanged', () => {
+  const fileSystem = createFileSystem()
+
+  fileSystem.writeFile('file.ts', 'content')
+  fileSystem.writeFile('file.ts', 'content')
+
+  expect(fileSystem.getVersion()).toBe('1')
+  expect(fileSystem.getScriptVersion('file.ts')).toBe('1')
 })
 
 test('createFileSystem should handle empty file content', () => {

--- a/packages/typescript-worker/test/ResolveTsconfig.test.ts
+++ b/packages/typescript-worker/test/ResolveTsconfig.test.ts
@@ -14,6 +14,8 @@ test('resolveTsconfig should return empty tsconfig for empty path', () => {
 
   expect(result).toBeDefined()
   expect(result.options).toBeDefined()
+  expect(result.options.allowJs).toBe(true)
+  expect(result.options.checkJs).toBe(true)
   expect(result.errors).toEqual([])
   expect(result.fileNames).toEqual([])
 })
@@ -63,6 +65,8 @@ test('resolveTsconfig should parse valid tsconfig', () => {
   expect(result.options.target).toBe(TypeScript.ScriptTarget.ES2020)
   expect(result.options.module).toBe(TypeScript.ModuleKind.ESNext)
   expect(result.options.strict).toBe(true)
+  expect(result.options.allowJs).toBe(true)
+  expect(result.options.checkJs).toBe(true)
   expect(result.errors).toEqual([])
   expect(Array.isArray(result.fileNames)).toBe(true)
 })

--- a/packages/typescript-worker/test/TypeScriptLanguageHost.test.ts
+++ b/packages/typescript-worker/test/TypeScriptLanguageHost.test.ts
@@ -1,5 +1,7 @@
 import { test, expect, jest } from '@jest/globals'
 import * as TypeScript from 'typescript'
+import { createFileSystem } from '../src/parts/CreateFileSystem/CreateFileSystem.ts'
+import { emptyTsconfig } from '../src/parts/EmptyTsConfig/EmptyTsConfig.ts'
 import { create } from '../src/parts/TypeScriptLanguageHost/TypeScriptLanguageHost.ts'
 
 test('create should return a language service host with proper methods', () => {
@@ -282,7 +284,7 @@ test('getProjectVersion should return string version', () => {
   const mockFileSystem = {
     getScriptFileNames: () => [],
     getScriptVersion: (uri: string) => '0',
-    getVersion: () => '0',
+    getVersion: () => '42',
     readFile: () => '',
     writeFile: (uri: string, content: string) => {},
   }
@@ -295,7 +297,7 @@ test('getProjectVersion should return string version', () => {
 
   const host = create(TypeScript, mockFileSystem, mockSyncRpc, mockOptions)
 
-  expect(host.getProjectVersion?.()).toBe('0')
+  expect(host.getProjectVersion?.()).toBe('42')
 })
 
 test('getScriptFileNames should return configured and file system script names', () => {
@@ -329,7 +331,7 @@ test('getScriptVersion should return string version', () => {
 
   const mockFileSystem = {
     getScriptFileNames: () => [],
-    getScriptVersion: (uri: string) => '0',
+    getScriptVersion: (uri: string) => '7',
     getVersion: () => '0',
     readFile: () => '',
     writeFile: (uri: string, content: string) => {},
@@ -343,7 +345,73 @@ test('getScriptVersion should return string version', () => {
 
   const host = create(TypeScript, mockFileSystem, mockSyncRpc, mockOptions)
 
-  expect(host.getScriptVersion?.('any-file.ts')).toBe('0')
+  expect(host.getScriptVersion?.('any-file.ts')).toBe('7')
+})
+
+test('language service should discover and refresh in-memory files', () => {
+  const fileSystem = createFileSystem()
+  const mockSyncRpc = {
+    invokeSync(method: string) {
+      if (method === 'SyncApi.exists') {
+        return false
+      }
+      if (method === 'SyncApi.readDirSync') {
+        return []
+      }
+      if (method === 'SyncApi.readFileSync') {
+        return ''
+      }
+      throw new Error(`unexpected method ${method}`)
+    },
+  }
+  const mockOptions = {
+    errors: [],
+    fileNames: [],
+    options: {
+      noLib: true,
+      strict: true,
+    },
+  }
+  const host = create(TypeScript, fileSystem, mockSyncRpc, mockOptions)
+  const languageService = TypeScript.createLanguageService(host)
+  const uri = 'fetch:///workspace/test.ts'
+
+  fileSystem.writeFile(uri, "let value: number = ''")
+  expect(languageService.getSemanticDiagnostics(uri).map((diagnostic) => diagnostic.code)).toEqual([2322])
+
+  fileSystem.writeFile(uri, 'let value: number = 1')
+  expect(languageService.getSemanticDiagnostics(uri)).toEqual([])
+})
+
+test('default project should report JavaScript diagnostics', () => {
+  const fileSystem = createFileSystem()
+  const mockSyncRpc = {
+    invokeSync(method: string) {
+      if (method === 'SyncApi.exists') {
+        return false
+      }
+      if (method === 'SyncApi.readDirSync') {
+        return []
+      }
+      if (method === 'SyncApi.readFileSync') {
+        return ''
+      }
+      throw new Error(`unexpected method ${method}`)
+    },
+  }
+  const host = create(TypeScript, fileSystem, mockSyncRpc, {
+    ...emptyTsconfig,
+    options: {
+      ...emptyTsconfig.options,
+      noLib: true,
+    },
+  })
+  const languageService = TypeScript.createLanguageService(host)
+  const uri = 'fetch:///workspace/test.js'
+
+  fileSystem.writeFile(uri, "let value = ''\nvalue++")
+
+  expect(languageService.getSemanticDiagnostics(uri).map((diagnostic) => diagnostic.code)).toContain(2356)
 })
 
 test('writeFile should throw error', () => {


### PR DESCRIPTION
Summary:
- refresh TypeScript language-service projects when in-memory files change
- check JavaScript by default and allow web worker library requests
- cover project refresh and JavaScript diagnostics with regression tests