### PR TITLE
fix: resolve nested relative imports

### DIFF
--- a/packages/e2e/fixtures/diagnostics-relative-parent-import/tsconfig.json
+++ b/packages/e2e/fixtures/diagnostics-relative-parent-import/tsconfig.json
@@ -5,6 +5,8 @@
     "module": "esnext",
     "moduleResolution": "nodenext",
     "allowImportingTsExtensions": true,
+    "composite": true,
     "noEmit": true
-  }
+  },
+  "include": ["packages/editor-worker/src", "packages/editor-worker/test"]
 }

--- a/packages/typescript-worker/src/parts/GetFiles/GetFiles.ts
+++ b/packages/typescript-worker/src/parts/GetFiles/GetFiles.ts
@@ -1,19 +1,62 @@
 import { isTypeScriptFile } from '../IsTypeScriptFile/IsTypeScriptFile.ts'
 
+const defaultExcludedDirectories = new Set(['bower_components', 'jspm_packages', 'node_modules'])
+
+const getSearchRoot = (pattern: string): string => {
+  const normalizedPattern = pattern
+    .replaceAll('\\', '/')
+    .replace(/^\.?\//, '')
+    .replace(/\/$/, '')
+  const wildcardIndex = normalizedPattern.search(/[*?]/)
+  if (wildcardIndex === -1) {
+    return isTypeScriptFile(normalizedPattern) ? '' : normalizedPattern
+  }
+  const slashIndex = normalizedPattern.lastIndexOf('/', wildcardIndex)
+  return slashIndex === -1 ? '' : normalizedPattern.slice(0, slashIndex)
+}
+
 export const getFiles = (
   basePath: string,
-  include: readonly string[],
+  include: readonly string[] | undefined,
   readDir: (uri: string) => readonly string[],
 ): readonly string[] => {
-  const dirents = readDir(basePath)
-  const childPaths = dirents.map((dirent) => `${basePath}/${dirent}`)
-  const allPaths = [...childPaths]
-  // TODO have a glob function for files
-  for (const childPath of childPaths) {
-    if (childPath.endsWith('/src')) {
-      allPaths.push(...getFiles(childPath, include, readDir))
+  if (include?.length === 0) {
+    return []
+  }
+  const files: string[] = []
+  const visitedDirectories = new Set<string>()
+  const visit = (directoryPath: string): void => {
+    if (visitedDirectories.has(directoryPath)) {
+      return
+    }
+    visitedDirectories.add(directoryPath)
+    let dirents: readonly string[]
+    try {
+      dirents = readDir(directoryPath)
+    } catch {
+      return
+    }
+    for (const dirent of dirents) {
+      const childPath = `${directoryPath}/${dirent}`
+      if (isTypeScriptFile(childPath)) {
+        files.push(childPath)
+        continue
+      }
+      if (dirent.includes('.') || defaultExcludedDirectories.has(dirent)) {
+        continue
+      }
+      visit(childPath)
     }
   }
-  const filteredPaths = allPaths.filter(isTypeScriptFile)
-  return filteredPaths
+
+  const searchRoots = include ? [...new Set(include.map(getSearchRoot))] : ['']
+  for (const searchRoot of searchRoots) {
+    const searchPath = searchRoot ? `${basePath}/${searchRoot}` : basePath
+    if (isTypeScriptFile(searchPath)) {
+      files.push(searchPath)
+    } else {
+      visit(searchPath)
+    }
+  }
+  return [...new Set(files)]
 }

--- a/packages/typescript-worker/src/parts/ResolveTsconfig/ResolveTsconfig.ts
+++ b/packages/typescript-worker/src/parts/ResolveTsconfig/ResolveTsconfig.ts
@@ -32,8 +32,10 @@ export const resolveTsconfig = (
     }
 
     const dirname = getParentPath(tsconfigPath)
-    const include = options.include || []
-    const files = getFiles(dirname, include as string[], readDir)
+    const include = parsed.files && !parsed.include ? [] : parsed.include
+    const discoveredFiles = getFiles(dirname, include, readDir)
+    const configuredFiles = (parsed.files || []).map((file: string) => `${dirname}/${file}`)
+    const files = [...new Set([...configuredFiles, ...discoveredFiles])]
     const result: TypeScript.ParsedCommandLine = {
       errors: [],
       fileNames: files as string[],

--- a/packages/typescript-worker/test/GetFiles.test.ts
+++ b/packages/typescript-worker/test/GetFiles.test.ts
@@ -19,7 +19,7 @@ test('getFiles should filter TypeScript files', () => {
     return []
   }
 
-  const result = getFiles('/project', [], readDir)
+  const result = getFiles('/project', undefined, readDir)
 
   expect(result).toEqual(['/project/file1.ts', '/project/file2.js'])
 })
@@ -41,14 +41,12 @@ test('getFiles should recursively search src directories', () => {
     return []
   }
 
-  const result = getFiles('/project', [], readDir)
+  const result = getFiles('/project', undefined, readDir)
 
   expect(result).toContain('/project/file1.ts')
   expect(result).toContain('/project/src/index.ts')
-  // The function only recursively searches directories ending with /src
-  // It doesn't recursively search subdirectories of /src
-  expect(result).not.toContain('/project/src/utils/helper.ts')
-  expect(result).not.toContain('/project/src/utils/constants.ts')
+  expect(result).toContain('/project/src/utils/helper.ts')
+  expect(result).toContain('/project/src/utils/constants.ts')
   // .tsx files are not considered TypeScript files by isTypeScriptFile
   expect(result).not.toContain('/project/src/components/Button.tsx')
   expect(result).not.toContain('/project/src/components/Modal.tsx')
@@ -68,13 +66,12 @@ test('getFiles should handle multiple src directories', () => {
     return []
   }
 
-  const result = getFiles('/project', [], readDir)
+  const result = getFiles('/project', undefined, readDir)
 
   expect(result).toContain('/project/file1.ts')
   expect(result).toContain('/project/src/index.ts')
-  // Note: tests directory is not /src so it won't be included
-  expect(result).not.toContain('/project/tests/test1.ts')
-  expect(result).not.toContain('/project/tests/test2.ts')
+  expect(result).toContain('/project/tests/test1.ts')
+  expect(result).toContain('/project/tests/test2.ts')
 })
 
 test('getFiles should handle nested src directories', () => {
@@ -94,14 +91,14 @@ test('getFiles should handle nested src directories', () => {
     return []
   }
 
-  const result = getFiles('/project', [], readDir)
+  const result = getFiles('/project', undefined, readDir)
 
   // .tsx files are not considered TypeScript files by isTypeScriptFile
   expect(result).not.toContain('/project/src/components/Button.tsx')
   expect(result).toContain('/project/src/src/deep.ts')
 })
 
-test('getFiles should handle include patterns (though not implemented)', () => {
+test('getFiles should handle include patterns', () => {
   const readDir = (uri: string): readonly string[] => {
     if (uri === '/project') {
       return ['src', 'file1.ts']
@@ -115,7 +112,6 @@ test('getFiles should handle include patterns (though not implemented)', () => {
   const include = ['src/**/*', '*.ts']
   const result = getFiles('/project', include, readDir)
 
-  // The function doesn't actually use include patterns yet, but should still work
   expect(result).toContain('/project/file1.ts')
   expect(result).toContain('/project/src/index.ts')
 })
@@ -133,8 +129,7 @@ test('getFiles should handle empty include array', () => {
 
   const result = getFiles('/project', [], readDir)
 
-  expect(result).toContain('/project/file1.ts')
-  expect(result).toContain('/project/src/index.ts')
+  expect(result).toEqual([])
 })
 
 test('getFiles should handle mixed file types', () => {
@@ -148,7 +143,7 @@ test('getFiles should handle mixed file types', () => {
     return []
   }
 
-  const result = getFiles('/project', [], readDir)
+  const result = getFiles('/project', undefined, readDir)
 
   expect(result).toContain('/project/file1.ts')
   expect(result).toContain('/project/file2.js')
@@ -182,11 +177,9 @@ test('getFiles should handle deep nesting', () => {
     return []
   }
 
-  const result = getFiles('/project', [], readDir)
+  const result = getFiles('/project', undefined, readDir)
 
-  // The function only recursively searches directories ending with /src
-  // So it won't find files in nested non-src directories
-  expect(result).toEqual([])
+  expect(result).toEqual(['/project/src/level1/level2/level3/deep.ts'])
 })
 
 test('getFiles should handle readDir errors gracefully', () => {
@@ -200,8 +193,5 @@ test('getFiles should handle readDir errors gracefully', () => {
     return []
   }
 
-  // The function should not throw, but may not include files from erroring directories
-  expect(() => {
-    getFiles('/project', [], readDir)
-  }).toThrow()
+  expect(getFiles('/project', undefined, readDir)).toEqual(['/project/file1.ts'])
 })

--- a/packages/typescript-worker/test/ResolveTsconfig.test.ts
+++ b/packages/typescript-worker/test/ResolveTsconfig.test.ts
@@ -238,6 +238,49 @@ test('resolveTsconfig should return empty tsconfig on error', () => {
   expect(result.fileNames).toEqual([])
 })
 
+test('resolveTsconfig should include nested files from configured source directories', () => {
+  const mockTsconfig = {
+    compilerOptions: {
+      composite: true,
+    },
+    include: ['src', 'test'],
+  }
+  const mockReadDir = (uri: string): readonly string[] => {
+    if (uri === '/project/src') {
+      return ['parts']
+    }
+    if (uri === '/project/src/parts') {
+      return ['ElectronDialog', 'GetWindowId']
+    }
+    if (uri === '/project/src/parts/ElectronDialog') {
+      return ['ElectronDialog.ts']
+    }
+    if (uri === '/project/src/parts/GetWindowId') {
+      return ['GetWindowId.ts']
+    }
+    if (uri === '/project/test') {
+      return ['ElectronDialog.test.ts']
+    }
+    return []
+  }
+
+  const result = resolveTsconfig(
+    '/project/tsconfig.json',
+    mockTsconfig,
+    () => '',
+    mockReadDir,
+    () => true,
+    TypeScript,
+  )
+
+  expect(result.options.configFilePath).toBe('/project/tsconfig.json')
+  expect(result.fileNames).toEqual([
+    '/project/src/parts/ElectronDialog/ElectronDialog.ts',
+    '/project/src/parts/GetWindowId/GetWindowId.ts',
+    '/project/test/ElectronDialog.test.ts',
+  ])
+})
+
 test('resolveTsconfig should handle complex tsconfig with multiple options', () => {
   const mockTsconfig = {
     compilerOptions: {


### PR DESCRIPTION
Summary:
- recursively enumerate TypeScript project files under configured include roots
- load nested sibling imports into composite projects so valid relative imports do not produce TS6307
- cover the composite relative-import scenario in unit and e2e fixtures