### PR TITLE
fix: use language service for references

### DIFF
--- a/packages/typescript-worker/src/parts/References/References.ts
+++ b/packages/typescript-worker/src/parts/References/References.ts
@@ -2,26 +2,13 @@ import * as FileReferences from '../FileReferences/FileReferences.ts'
 import { getOffset } from '../GetOffset/GetOffset.ts'
 import { getOrCreateLanguageService } from '../GetOrCreateLanguageService/GetOrCreateLanguageService.ts'
 import { getReferencesFromTsResult2 } from '../GetReferencesFromTsResult2/GetReferencesFromTsResult2.ts'
-import * as GetReferencesFromTsResult from '../GetReferencesFromTsResult/GetReferencesFromTsResult.ts'
-import * as Position from '../Position/Position.ts'
 import * as Rpc from '../Rpc/Rpc.ts'
-import * as TextDocumentSync from '../TextDocumentSync/TextDocumentSync.ts'
-import * as TypeScriptRpc from '../TypeScriptRpc/TypeScriptRpc.ts'
-
-const getReferences = async (textDocument: any, offset: number) => {
-  await TextDocumentSync.openTextDocuments([textDocument])
-  const tsPosition = await Position.getTsPosition(textDocument, offset)
-  const tsResult = await TypeScriptRpc.invoke('References.getReferences', {
-    file: textDocument.uri,
-    line: tsPosition.line,
-    offset: tsPosition.offset,
-  })
-  return tsResult
-}
 
 export const provideReferences = async (textDocument: any, offset: number) => {
-  const tsResult = await getReferences(textDocument, offset)
-  const references = GetReferencesFromTsResult.getReferencesFromTsResult(textDocument, tsResult)
+  const { fs, languageService } = getOrCreateLanguageService(textDocument.uri)
+  fs.writeFile(textDocument.uri, textDocument.text)
+  const tsResult = languageService.getReferencesAtPosition(textDocument.uri, offset)
+  const references = await getReferencesFromTsResult2(tsResult, fs)
   return references
 }
 

--- a/packages/typescript-worker/test/References.test.ts
+++ b/packages/typescript-worker/test/References.test.ts
@@ -14,32 +14,54 @@ jest.unstable_mockModule('../src/parts/Rpc/Rpc.ts', () => {
     invoke: jest.fn(),
   }
 })
+jest.unstable_mockModule('../src/parts/GetOrCreateLanguageService/GetOrCreateLanguageService.ts', () => {
+  return {
+    getOrCreateLanguageService: jest.fn(),
+  }
+})
 
 const References = await import('../src/parts/References/References.ts')
 const TypeScriptRpc = await import('../src/parts/TypeScriptRpc/TypeScriptRpc.ts')
 const Rpc = await import('../src/parts/Rpc/Rpc.ts')
+const GetOrCreateLanguageService = await import('../src/parts/GetOrCreateLanguageService/GetOrCreateLanguageService.ts')
 
 test('provideReferences', async () => {
-  jest.spyOn(TypeScriptRpc, 'invoke').mockImplementation(async (method) => {
-    if (method === 'References.getReferences') {
-      return {
-        refs: [],
-      }
-    }
-  })
-  jest.spyOn(Rpc, 'invoke').mockImplementation(async (method) => {
-    if (method === 'Position.getPosition') {
-      return {
-        columnIndex: 0,
-        rowIndex: 0,
-      }
-    }
-  })
+  const writeFile = jest.fn()
+  const getReferencesAtPosition = jest.fn((_uri: string, _offset: number) => [
+    {
+      fileName: 'file:///test.ts',
+      textSpan: {
+        length: 5,
+        start: 6,
+      },
+    },
+  ])
+  jest.spyOn(GetOrCreateLanguageService, 'getOrCreateLanguageService').mockReturnValue({
+    fs: {
+      readFile: jest.fn(() => 'const value = 1'),
+      writeFile,
+    },
+    languageService: {
+      getReferencesAtPosition,
+    },
+  } as any)
   const textDocument = {
-    uri: '',
+    text: 'const value = 1',
+    uri: 'file:///test.ts',
   }
-  const offset = 0
-  expect(await References.provideReferences(textDocument, offset)).toEqual([])
+  const offset = 7
+  expect(await References.provideReferences(textDocument, offset)).toEqual([
+    {
+      endColumnIndex: 11,
+      endRowIndex: 0,
+      startColumnIndex: 6,
+      startRowIndex: 0,
+      uri: 'file:///test.ts',
+    },
+  ])
+  expect(writeFile).toHaveBeenCalledWith(textDocument.uri, textDocument.text)
+  expect(getReferencesAtPosition).toHaveBeenCalledWith(textDocument.uri, offset)
+  expect(TypeScriptRpc.invoke).not.toHaveBeenCalled()
 })
 
 test('provideFileReferences', async () => {


### PR DESCRIPTION
Fix Find All References by using the TypeScript worker's local language service instead of the removed UpdateOpen command. Preserve current in-memory document contents and add regression coverage for the provider path.