### PR TITLE
fix: enable definitions for typescript react

### DIFF
--- a/packages/e2e/fixtures/definition-tsx/src/App.tsx
+++ b/packages/e2e/fixtures/definition-tsx/src/App.tsx
@@ -1,0 +1,3 @@
+export default function App() {
+  return <main>Hello</main>
+}

--- a/packages/e2e/fixtures/definition-tsx/src/main.tsx
+++ b/packages/e2e/fixtures/definition-tsx/src/main.tsx
@@ -1,0 +1,3 @@
+import App from './App.tsx'
+
+App

--- a/packages/e2e/fixtures/definition-tsx/tsconfig.json
+++ b/packages/e2e/fixtures/definition-tsx/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/packages/e2e/src/typescript.definition-tsx.ts
+++ b/packages/e2e/src/typescript.definition-tsx.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.definition-tsx'
+
+export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main, Workspace }) => {
+  const fixtureUrl = import.meta.resolve('../fixtures/definition-tsx')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Main.openUri(`${workspaceUrl}/src/main.tsx`)
+  await Editor.setCursor(0, 8)
+
+  await Editor.goToDefinition()
+
+  const mainTabs = Locator('.MainTab')
+  await expect(mainTabs).toHaveCount(2)
+  await expect(mainTabs.nth(1)).toHaveText('App.tsx')
+}

--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -15,6 +15,7 @@
     "onCompletion:javascript",
     "onDefinition:javascript",
     "onDefinition:typescript",
+    "onDefinition:typescriptreact",
     "onDiagnostic:javascript",
     "onDiagnostic:typescript",
     "onLanguage:javascript",


### PR DESCRIPTION
Enables the isolated TypeScript definition provider for TypeScript React documents. Adds end-to-end coverage for navigating from a TSX import to its TSX definition.