### PR TITLE
fix: support references in typescript react

### DIFF
--- a/packages/e2e/src/typescript.references-tsx.ts
+++ b/packages/e2e/src/typescript.references-tsx.ts
@@ -1,6 +1,6 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
 
-export const name = 'typescript.definition-tsx'
+export const name = 'typescript.references-tsx'
 
 export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main, Workspace }) => {
   const fixtureUrl = import.meta.resolve('../fixtures/definition-tsx')
@@ -9,10 +9,10 @@ export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main, Wo
   await Main.openUri(`${workspaceUrl}/src/main.tsx`)
   await Editor.setCursor(0, 8)
 
-  await Editor.goToDefinition()
+  await Editor.findAllReferences()
 
-  const mainTabs = Locator('.MainTab')
-  await expect(mainTabs).toHaveCount(2)
-  const appTab = mainTabs.nth(1)
-  await expect(appTab).toHaveText('App.tsx')
+  const viewletLocations = Locator('.Locations')
+  await expect(viewletLocations).toBeVisible()
+  const viewletReferencesMessage = Locator('.LocationsMessage')
+  await expect(viewletReferencesMessage).toHaveText('3 results in 2 files')
 }

--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -26,6 +26,7 @@
     "onRename:typescript",
     "onReferences:javascript",
     "onReferences:typescript",
+    "onReferences:typescriptreact",
     "onImplementation:javascript",
     "onImplementation:typescript",
     "onClosingTag:javascript",
@@ -33,6 +34,7 @@
     "onTypeDefinition:typescript",
     "onHover:javascript",
     "onHover:typescript",
+    "onHover:typescriptreact",
     "onTabCompletion:javascript",
     "onTabCompletion:typescript"
   ],

--- a/packages/typescript-worker/src/parts/TypeScriptLanguageHost/TypeScriptLanguageHost.ts
+++ b/packages/typescript-worker/src/parts/TypeScriptLanguageHost/TypeScriptLanguageHost.ts
@@ -20,6 +20,23 @@ const doesSurelyNotExist = (path: string): boolean => {
   return false
 }
 
+const getScriptKind = (ts: typeof TypeScript, fileName: string): TypeScript.ScriptKind => {
+  const lowerCaseFileName = fileName.toLowerCase()
+  if (lowerCaseFileName.endsWith('.tsx')) {
+    return ts.ScriptKind.TSX
+  }
+  if (lowerCaseFileName.endsWith('.jsx')) {
+    return ts.ScriptKind.JSX
+  }
+  if (lowerCaseFileName.endsWith('.js') || lowerCaseFileName.endsWith('.mjs') || lowerCaseFileName.endsWith('.cjs')) {
+    return ts.ScriptKind.JS
+  }
+  if (lowerCaseFileName.endsWith('.json')) {
+    return ts.ScriptKind.JSON
+  }
+  return ts.ScriptKind.TS
+}
+
 export const create = (
   ts: typeof TypeScript,
   fileSystem: IFileSystem,
@@ -79,7 +96,7 @@ export const create = (
       return [...new Set([...options.fileNames, ...files])]
     },
     getScriptKind(fileName) {
-      return ts.ScriptKind.TS
+      return getScriptKind(ts, fileName)
     },
     getScriptSnapshot(fileName) {
       if (isLibFile(fileName)) {

--- a/packages/typescript-worker/test/TypeScriptLanguageHost.test.ts
+++ b/packages/typescript-worker/test/TypeScriptLanguageHost.test.ts
@@ -65,7 +65,7 @@ test('create should return a language service host with proper methods', () => {
   expect(typeof host.getProjectReferences).toBe('function')
 })
 
-test('getScriptKind should return TS for all files', () => {
+test('getScriptKind should return the kind matching the file extension', () => {
   globalThis.rpc = {
     invoke: jest.fn(() => Promise.resolve()),
   }
@@ -87,8 +87,13 @@ test('getScriptKind should return TS for all files', () => {
   const host = create(TypeScript, mockFileSystem, mockSyncRpc, mockOptions)
 
   expect(host.getScriptKind?.('test.ts')).toBe(TypeScript.ScriptKind.TS)
-  expect(host.getScriptKind?.('test.js')).toBe(TypeScript.ScriptKind.TS)
-  expect(host.getScriptKind?.('test.tsx')).toBe(TypeScript.ScriptKind.TS)
+  expect(host.getScriptKind?.('test.tsx')).toBe(TypeScript.ScriptKind.TSX)
+  expect(host.getScriptKind?.('test.js')).toBe(TypeScript.ScriptKind.JS)
+  expect(host.getScriptKind?.('test.mjs')).toBe(TypeScript.ScriptKind.JS)
+  expect(host.getScriptKind?.('test.cjs')).toBe(TypeScript.ScriptKind.JS)
+  expect(host.getScriptKind?.('test.jsx')).toBe(TypeScript.ScriptKind.JSX)
+  expect(host.getScriptKind?.('test.json')).toBe(TypeScript.ScriptKind.JSON)
+  expect(host.getScriptKind?.('test.unknown')).toBe(TypeScript.ScriptKind.TS)
 })
 
 test('directoryExists should always return true', () => {


### PR DESCRIPTION
## Summary

- activate hover and references providers for TypeScript React documents
- classify TSX, JSX, JavaScript, and JSON files with the correct TypeScript script kind
- add focused TSX references coverage and fix the existing TSX definition test lint violation

## Testing

- npm test -- --runInBand
- npm run type-check
- npm run lint
- focused headless typescript.references-tsx e2e test