### PR TITLE
fix: stabilize TypeScript project navigation

### DIFF
--- a/packages/e2e/src/typescript.definition-same-file.ts
+++ b/packages/e2e/src/typescript.definition-same-file.ts
@@ -18,5 +18,5 @@ export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main, Wo
   await expect(mainTabs).toHaveCount(1)
   const mainTabTwo = mainTabs.nth(0)
   await expect(mainTabTwo).toHaveText('test.ts')
-  await Editor.shouldHaveSelections(new Uint32Array([0, 0, 0, 0]))
+  await Editor.shouldHaveSelections(new Uint32Array([0, 6, 0, 6]))
 }

--- a/packages/extension/src/parts/SyncApi/SyncApi.ts
+++ b/packages/extension/src/parts/SyncApi/SyncApi.ts
@@ -58,7 +58,7 @@ export const exists = async (id: number, uri: string): Promise<void> => {
       const result = await existsApi(toFileUri(uri))
       return result
     } catch {
-      return true
+      return false
     }
   }
   await writeResult(id, resultGenerator)

--- a/packages/extension/test/SyncApi.test.ts
+++ b/packages/extension/test/SyncApi.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const existsApi = jest.fn<() => Promise<boolean>>()
+const writeResultValue = jest.fn()
+
+jest.unstable_mockModule('@lvce-editor/api', () => ({
+  exists: existsApi,
+  readDirWithFileTypes: jest.fn(),
+  readFile: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/WriteResult/WriteResult.ts', () => ({
+  writeResult: async (_id: number, resultGenerator: () => Promise<unknown>) => {
+    writeResultValue(await resultGenerator())
+  },
+}))
+
+const SyncApi = await import('../src/parts/SyncApi/SyncApi.ts')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('exists writes false when checking a missing file throws', async () => {
+  existsApi.mockRejectedValue(new Error('file not found'))
+
+  await SyncApi.exists(1, '/workspace/node_modules/package/types.d.ts')
+
+  expect(writeResultValue).toHaveBeenCalledWith(false)
+})
+
+test('exists writes the filesystem result', async () => {
+  existsApi.mockResolvedValue(true)
+
+  await SyncApi.exists(1, '/workspace/src/main.ts')
+
+  expect(writeResultValue).toHaveBeenCalledWith(true)
+})

--- a/packages/typescript-worker/src/parts/CreateModuleResolver/CreateModuleResolver.ts
+++ b/packages/typescript-worker/src/parts/CreateModuleResolver/CreateModuleResolver.ts
@@ -19,6 +19,10 @@ const getExtension = (fileName: string): string => {
   return fileName.slice(dotIndex)
 }
 
+const usesTypeScriptExtension = (moduleName: string): boolean => {
+  return /\.(?:[cm]?ts|tsx)$/.test(moduleName)
+}
+
 const isNode = (path: string): boolean => {
   return path.startsWith('node:')
 }
@@ -40,36 +44,69 @@ const toFileUri = (path: string): string => {
 }
 
 const resolveRelativePath = (containingFile: string, text: string): string => {
+  const normalizedContainingFile = containingFile.replaceAll('\\', '/')
   const containingFileUri = toFileUri(containingFile)
-  return new URL(text, containingFileUri).href
+  const resolved = new URL(text, containingFileUri)
+  if (normalizedContainingFile.startsWith('file://')) {
+    return resolved.href
+  }
+  if (normalizedContainingFile.startsWith('/')) {
+    return decodeURIComponent(resolved.pathname)
+  }
+  if (windowsAbsolutePathRegex.test(normalizedContainingFile)) {
+    return decodeURIComponent(resolved.pathname.slice(1))
+  }
+  return resolved.href
 }
 
-const getRelativeModuleName = (containingFile: string, text: string): string => {
+const getRelativeModuleNames = (containingFile: string, text: string): readonly string[] => {
   const normalizedContainingFile = containingFile.replaceAll('\\', '/')
   const isInNodeModules =
     normalizedContainingFile.startsWith('node_modules/') || normalizedContainingFile.includes('/node_modules/')
   const isDeclarationFile = normalizedContainingFile.endsWith('.d.ts')
   if (isInNodeModules && isDeclarationFile && text.endsWith('.ts') && !text.endsWith('.d.ts')) {
-    return `${text.slice(0, -3)}.d.ts`
+    return [`${text.slice(0, -3)}.d.ts`, text]
+  }
+  if (isInNodeModules && isDeclarationFile && text.endsWith('.d')) {
+    return [`${text}.ts`, text]
   }
   const baseName = text.slice(text.lastIndexOf('/') + 1)
   if (isInNodeModules && isDeclarationFile && !baseName.includes('.')) {
-    return `${text}.d.ts`
+    return [`${text}.d.ts`, `${text}.ts`]
   }
-  return text
+  return [text]
 }
 
-const resolveModuleNameRelative = (containingFile: string, text: string): ResolvedModuleWithFailedLookupLocations => {
-  const relativeModuleName = getRelativeModuleName(containingFile, text)
-  const resolveFileName = resolveRelativePath(containingFile, relativeModuleName)
-  const extension = getExtension(resolveFileName)
+const getExistingRelativeModuleName = (syncRpc: Readonly<SyncRpc>, containingFile: string, text: string): string => {
+  const relativeModuleNames = getRelativeModuleNames(containingFile, text)
+  for (const relativeModuleName of relativeModuleNames) {
+    const resolvedFileName = resolveRelativePath(containingFile, relativeModuleName)
+    try {
+      if (syncRpc.invokeSync('SyncApi.exists', resolvedFileName)) {
+        return relativeModuleName
+      }
+    } catch {
+      // Fall back to the preferred candidate when synchronous file access is unavailable.
+    }
+  }
+  return relativeModuleNames[0]
+}
+
+const resolveModuleNameRelative = (
+  syncRpc: Readonly<SyncRpc>,
+  containingFile: string,
+  text: string,
+): ResolvedModuleWithFailedLookupLocations => {
+  const relativeModuleName = getExistingRelativeModuleName(syncRpc, containingFile, text)
+  const resolvedFileName = resolveRelativePath(containingFile, relativeModuleName)
+  const extension = getExtension(resolvedFileName)
   return {
     resolvedModule: {
       extension,
       isExternalLibraryImport: false,
       packageId: undefined,
-      resolvedFileName: resolveFileName,
-      resolvedUsingTsExtension: true,
+      resolvedFileName,
+      resolvedUsingTsExtension: usesTypeScriptExtension(text),
     },
   }
 }
@@ -148,7 +185,7 @@ export const createModuleResolver = (syncRpc: Readonly<SyncRpc>): ModuleResolver
       }
     }
     if (text.startsWith('./') || text.startsWith('../')) {
-      return resolveModuleNameRelative(containingFile, text)
+      return resolveModuleNameRelative(syncRpc, containingFile, text)
     }
     return resolveModuleNodeModules(syncRpc, containingFile, text)
   }

--- a/packages/typescript-worker/src/parts/Definition2/Definition2.ts
+++ b/packages/typescript-worker/src/parts/Definition2/Definition2.ts
@@ -1,10 +1,13 @@
 import { getDefinitionFromTsResult2 } from '../GetDefinitionFromTsResult2/GetDefinitionFromTsResult2.ts'
 import { getOrCreateLanguageService } from '../GetOrCreateLanguageService/GetOrCreateLanguageService.ts'
+import * as Rpc from '../Rpc/Rpc.ts'
 
 export const getDefinition2 = async (textDocument: any, offset: number) => {
   const { fs, languageService } = getOrCreateLanguageService(textDocument.uri)
   fs.writeFile(textDocument.uri, textDocument.text)
   const tsResult = languageService.getDefinitionAtPosition(textDocument.uri, offset)
-  const definition = await getDefinitionFromTsResult2(textDocument, tsResult || [])
+  const definition = await getDefinitionFromTsResult2(tsResult || [], fs, (uri) =>
+    Rpc.invoke('FileSystem.readFile', uri),
+  )
   return definition
 }

--- a/packages/typescript-worker/src/parts/GetDefinitionFromTsResult2/GetDefinitionFromTsResult2.ts
+++ b/packages/typescript-worker/src/parts/GetDefinitionFromTsResult2/GetDefinitionFromTsResult2.ts
@@ -1,4 +1,6 @@
 import type ts from 'typescript'
+import type { IFileSystem } from '../IFileSystem/IFileSystem.ts'
+import { getPositionAt } from '../GetPositionAt/GetPositionAt.ts'
 
 const getUri = (fileName: string) => {
   if (fileName.includes('/node_modules/@typescript/lib') || fileName.includes('node_modules/@typescript/lib')) {
@@ -13,54 +15,29 @@ const getUri = (fileName: string) => {
   return fileName
 }
 
-export const getDefinitionFromTsResult2 = async (textDocument: any, tsResult: readonly ts.DefinitionInfo[]) => {
+export const getDefinitionFromTsResult2 = async (
+  tsResult: readonly ts.DefinitionInfo[],
+  fs: IFileSystem,
+  readFile: (uri: string) => Promise<string>,
+) => {
   if (tsResult.length === 0) {
     return undefined
   }
   const firstDefinition = tsResult[0]
-  const uri = getUri(firstDefinition.fileName)
-  let startOffset = 0
-  let endOffset = 0
-  if (firstDefinition.contextSpan) {
-    startOffset = firstDefinition.contextSpan.start
-    endOffset = firstDefinition.contextSpan.start + firstDefinition.contextSpan.length
-  }
+  const { fileName, textSpan } = firstDefinition
+  const uri = getUri(fileName)
+  const text = fs.readFile(fileName) || (await readFile(fileName))
+  const startOffset = textSpan.start
+  const endOffset = textSpan.start + textSpan.length
+  const startPosition = getPositionAt(text, startOffset)
+  const endPosition = getPositionAt(text, endOffset)
   return {
+    endColumnIndex: endPosition.columnIndex,
     endOffset,
+    endRowIndex: endPosition.rowIndex,
+    startColumnIndex: startPosition.columnIndex,
     startOffset,
+    startRowIndex: startPosition.rowIndex,
     uri,
   }
-  // const { textSpan } = firstDefinition
-  // if (file === textDocument.uri) {
-  //   // TODO
-  //   const startOffset = 0
-  //   //  await Position.getOffset(textDocument, {
-  //   //   rowIndex: start.line - 1,
-  //   //   columnIndex: start.offset - 1,
-  //   // })
-
-  //   const endOffset = await 0
-  //   //  Position.getOffset(textDocument, {
-  //   //   rowIndex: end.line - 1,
-  //   //   columnIndex: end.offset - 1,
-  //   // })
-  //   return {
-  //     uri: file,
-  //     startOffset,
-  //     endOffset,
-  //   }
-  // }
-  // TODO want offset based result
-  // probably would require to read file and map position to offset (very slow)
-  // const startOffset = 0
-  // const endOffset = 0
-  // return {
-  //   uri: file,
-  //   startRowIndex: start.line - 1,
-  //   startColumnIndex: start.offset - 1,
-  //   endRowIndex: end.line - 1,
-  //   endColumnIndex: end.offset - 1,
-  //   startOffset,
-  //   endOffset,
-  // }
 }

--- a/packages/typescript-worker/src/parts/GetOrCreateLanguageService/GetOrCreateLanguageService.ts
+++ b/packages/typescript-worker/src/parts/GetOrCreateLanguageService/GetOrCreateLanguageService.ts
@@ -12,7 +12,7 @@ const projectIdCache: Record<string, number> = Object.create(null)
 export const getOrCreateLanguageService = (uri: string) => {
   const id = 1
   const { client, fs, ts } = LanguageServices.get(id)
-  if (uri in projectCache) {
+  if (uri in projectIdCache) {
     const projectId = projectIdCache[uri]
     const languageService = projectCache[projectId]
     return {
@@ -24,12 +24,15 @@ export const getOrCreateLanguageService = (uri: string) => {
   const readFile = (uri: string) => client.invokeSync('SyncApi.readFileSync', uri)
   const readDir = (uri: string) => client.invokeSync('SyncApi.readDirSync', uri)
   const tsConfigPath = getTsConfigPath(uri, exists)
-  const parsed = parseTsconfig(tsConfigPath, readFile)
+  const parsed = parseTsconfig(tsConfigPath, readFile, ts)
   const resolved = resolveTsconfig(tsConfigPath, parsed, readFile, readDir, exists, ts)
   const languageService = createTypeScriptLanguageService(ts, fs, client, resolved)
   const projectId = projectIds.next++
   projectCache[projectId] = languageService
   projectIdCache[uri] = projectId
+  for (const fileName of resolved.fileNames) {
+    projectIdCache[fileName] = projectId
+  }
 
   return {
     fs,

--- a/packages/typescript-worker/src/parts/GetReferencesFromTsResult2/GetReferencesFromTsResult2.ts
+++ b/packages/typescript-worker/src/parts/GetReferencesFromTsResult2/GetReferencesFromTsResult2.ts
@@ -12,9 +12,13 @@ const formatLibFileMaybe = (uri: string): string => {
   return formattedUrl
 }
 
-const getReferenceFromTsResult = (reference: ts.ReferenceEntry, fs: IFileSystem) => {
+const getReferenceFromTsResult = async (
+  reference: ts.ReferenceEntry,
+  fs: IFileSystem,
+  readFile: (uri: string) => Promise<string>,
+) => {
   const { fileName, textSpan } = reference
-  const text = fs.readFile(fileName)
+  const text = fs.readFile(fileName) || (await readFile(fileName))
   const startPosition = getPositionAt(text, textSpan.start)
   const endPosition = getPositionAt(text, textSpan.start + textSpan.length)
   const formattedUri = formatLibFileMaybe(fileName)
@@ -30,10 +34,11 @@ const getReferenceFromTsResult = (reference: ts.ReferenceEntry, fs: IFileSystem)
 export const getReferencesFromTsResult2 = async (
   tsResult: readonly ts.ReferenceEntry[] | undefined,
   fs: IFileSystem,
+  readFile: (uri: string) => Promise<string>,
 ) => {
   if (!tsResult) {
     return []
   }
-  const references = tsResult.map((item) => getReferenceFromTsResult(item, fs))
+  const references = await Promise.all(tsResult.map((item) => getReferenceFromTsResult(item, fs, readFile)))
   return references
 }

--- a/packages/typescript-worker/src/parts/ParseTsconfig/ParseTsconfig.ts
+++ b/packages/typescript-worker/src/parts/ParseTsconfig/ParseTsconfig.ts
@@ -1,11 +1,16 @@
-export const parseTsconfig = (tsconfigPath: string, readFile: (uri: string) => string): any => {
+import type * as TypeScript from 'typescript'
+
+export const parseTsconfig = (tsconfigPath: string, readFile: (uri: string) => string, ts: typeof TypeScript): any => {
   if (!tsconfigPath) {
     return {}
   }
   try {
     const content = readFile(tsconfigPath)
-    const parsed = JSON.parse(content)
-    return parsed
+    const { config, error } = ts.parseConfigFileTextToJson(tsconfigPath, content)
+    if (error) {
+      return {}
+    }
+    return config
   } catch {
     return {}
   }

--- a/packages/typescript-worker/src/parts/References/References.ts
+++ b/packages/typescript-worker/src/parts/References/References.ts
@@ -8,7 +8,7 @@ export const provideReferences = async (textDocument: any, offset: number) => {
   const { fs, languageService } = getOrCreateLanguageService(textDocument.uri)
   fs.writeFile(textDocument.uri, textDocument.text)
   const tsResult = languageService.getReferencesAtPosition(textDocument.uri, offset)
-  const references = await getReferencesFromTsResult2(tsResult, fs)
+  const references = await getReferencesFromTsResult2(tsResult, fs, (uri) => Rpc.invoke('FileSystem.readFile', uri))
   return references
 }
 
@@ -19,7 +19,7 @@ export const provideReferences2 = async ({ position, uri }) => {
   fs.writeFile(uri, text)
   const offset = getOffset(text, position.rowIndex, position.columnIndex)
   const tsResult = languageService.getReferencesAtPosition(uri, offset)
-  const references = await getReferencesFromTsResult2(tsResult, fs)
+  const references = await getReferencesFromTsResult2(tsResult, fs, (uri) => Rpc.invoke('FileSystem.readFile', uri))
   return references
 }
 

--- a/packages/typescript-worker/src/parts/WaitForSyncRpcResultBuffer/WaitForSyncRpcResultBuffer.ts
+++ b/packages/typescript-worker/src/parts/WaitForSyncRpcResultBuffer/WaitForSyncRpcResultBuffer.ts
@@ -6,7 +6,7 @@ export const waitForSyncRpcResultBuffer = (maxWaitTime: number, sharedBuffer: In
     return WaitForSyncBufferResultType.Ok
   }
   if (result === 'not-equal') {
-    return WaitForSyncBufferResultType.NotEqual
+    return WaitForSyncBufferResultType.Ok
   }
   if (result === 'timed-out') {
     return WaitForSyncBufferResultType.Timeout

--- a/packages/typescript-worker/test/CreateModuleResolver.test.ts
+++ b/packages/typescript-worker/test/CreateModuleResolver.test.ts
@@ -69,7 +69,7 @@ test('createModuleResolver should handle relative imports starting with ./', () 
 
   expect(result.resolvedModule).toBeDefined()
   expect(result.resolvedModule?.extension).toBe('')
-  expect(result.resolvedModule?.resolvedFileName).toBe('file:///path/to/relative-module')
+  expect(result.resolvedModule?.resolvedFileName).toBe('/path/to/relative-module')
 })
 
 test('createModuleResolver should handle relative imports starting with ../', () => {
@@ -89,7 +89,7 @@ test('createModuleResolver should handle relative imports starting with ../', ()
 
   expect(result.resolvedModule).toBeDefined()
   expect(result.resolvedModule?.extension).toBe('')
-  expect(result.resolvedModule?.resolvedFileName).toBe('file:///path/parent-module')
+  expect(result.resolvedModule?.resolvedFileName).toBe('/path/parent-module')
 })
 
 test('createModuleResolver should normalize relative imports from file uris', () => {
@@ -118,7 +118,7 @@ test('createModuleResolver should normalize relative imports from file uris', ()
   )
 })
 
-test('createModuleResolver should resolve relative imports from absolute file paths as file uris', () => {
+test('createModuleResolver should preserve absolute file paths for relative imports', () => {
   globalThis.rpc = {
     invoke: jest.fn(() => Promise.resolve()),
   }
@@ -140,7 +140,7 @@ test('createModuleResolver should resolve relative imports from absolute file pa
   expect(result.resolvedModule).toBeDefined()
   expect(result.resolvedModule?.extension).toBe('.ts')
   expect(result.resolvedModule?.resolvedFileName).toBe(
-    'file:///workspace/editor-worker/packages/editor-worker/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts',
+    '/workspace/editor-worker/packages/editor-worker/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts',
   )
 })
 
@@ -155,9 +155,7 @@ test('createModuleResolver should resolve .ts imports from declaration files in 
 
   expect(result.resolvedModule).toBeDefined()
   expect(result.resolvedModule?.extension).toBe('.d.ts')
-  expect(result.resolvedModule?.resolvedFileName).toBe(
-    'file:///project/node_modules/abc/parts/Activation/Activation.d.ts',
-  )
+  expect(result.resolvedModule?.resolvedFileName).toBe('/project/node_modules/abc/parts/Activation/Activation.d.ts')
 })
 
 test('createModuleResolver should resolve extensionless imports from declaration files in node_modules as .d.ts files', () => {
@@ -171,7 +169,45 @@ test('createModuleResolver should resolve extensionless imports from declaration
 
   expect(result.resolvedModule).toBeDefined()
   expect(result.resolvedModule?.extension).toBe('.d.ts')
-  expect(result.resolvedModule?.resolvedFileName).toBe('file:///project/node_modules/undici-types/dispatcher.d.ts')
+  expect(result.resolvedModule?.resolvedFileName).toBe('/project/node_modules/undici-types/dispatcher.d.ts')
+})
+
+test('createModuleResolver should fall back to a TypeScript source when a declaration import has no declaration file', () => {
+  const invokeSync = jest.fn((method: string, uri: string) => {
+    if (method === 'SyncApi.exists') {
+      return uri === '/project/node_modules/picocolors/types.ts'
+    }
+    throw new Error(`unexpected method ${method}`)
+  })
+  const resolver = createModuleResolver({ invokeSync })
+
+  const result = resolver('./types', '/project/node_modules/picocolors/picocolors.d.ts', {
+    target: TypeScript.ScriptTarget.ES2020,
+  })
+
+  expect(result.resolvedModule?.extension).toBe('.ts')
+  expect(result.resolvedModule?.resolvedFileName).toBe('/project/node_modules/picocolors/types.ts')
+  expect(result.resolvedModule?.resolvedUsingTsExtension).toBe(false)
+  expect(invokeSync).toHaveBeenNthCalledWith(1, 'SyncApi.exists', '/project/node_modules/picocolors/types.d.ts')
+  expect(invokeSync).toHaveBeenNthCalledWith(2, 'SyncApi.exists', '/project/node_modules/picocolors/types.ts')
+})
+
+test('createModuleResolver should resolve declaration imports ending in .d', () => {
+  const invokeSync = jest.fn((method: string, uri: string) => {
+    if (method === 'SyncApi.exists') {
+      return uri === '/project/node_modules/tailwindcss/types/config.d.ts'
+    }
+    throw new Error(`unexpected method ${method}`)
+  })
+  const resolver = createModuleResolver({ invokeSync })
+
+  const result = resolver('./config.d', '/project/node_modules/tailwindcss/types/index.d.ts', {
+    target: TypeScript.ScriptTarget.ES2020,
+  })
+
+  expect(result.resolvedModule?.extension).toBe('.d.ts')
+  expect(result.resolvedModule?.resolvedFileName).toBe('/project/node_modules/tailwindcss/types/config.d.ts')
+  expect(result.resolvedModule?.resolvedUsingTsExtension).toBe(false)
 })
 
 test('createModuleResolver should preserve .d.ts imports from declaration files in node_modules', () => {
@@ -183,9 +219,7 @@ test('createModuleResolver should preserve .d.ts imports from declaration files 
     target: TypeScript.ScriptTarget.ES2020,
   })
 
-  expect(result.resolvedModule?.resolvedFileName).toBe(
-    'file:///project/node_modules/abc/parts/Activation/Activation.d.ts',
-  )
+  expect(result.resolvedModule?.resolvedFileName).toBe('/project/node_modules/abc/parts/Activation/Activation.d.ts')
 })
 
 test('createModuleResolver should preserve .ts imports outside node_modules', () => {
@@ -197,7 +231,7 @@ test('createModuleResolver should preserve .ts imports outside node_modules', ()
     target: TypeScript.ScriptTarget.ES2020,
   })
 
-  expect(result.resolvedModule?.resolvedFileName).toBe('file:///project/src/parts/Activation/Activation.ts')
+  expect(result.resolvedModule?.resolvedFileName).toBe('/project/src/parts/Activation/Activation.ts')
 })
 
 test('createModuleResolver should resolve node modules with package.json', () => {

--- a/packages/typescript-worker/test/GetDefinitionFromTsResult2.test.ts
+++ b/packages/typescript-worker/test/GetDefinitionFromTsResult2.test.ts
@@ -1,0 +1,48 @@
+import { expect, jest, test } from '@jest/globals'
+import ts from 'typescript'
+import { createFileSystem } from '../src/parts/CreateFileSystem/CreateFileSystem.ts'
+import { getDefinitionFromTsResult2 } from '../src/parts/GetDefinitionFromTsResult2/GetDefinitionFromTsResult2.ts'
+
+test('loads the target file and converts its symbol span', async () => {
+  const fs = createFileSystem()
+  const readFile = jest.fn<(uri: string) => Promise<string>>(async () => {
+    return 'export default function App() {}'
+  })
+
+  const definition = await getDefinitionFromTsResult2(
+    [
+      {
+        containerKind: ts.ScriptElementKind.unknown,
+        containerName: '"./App.tsx"',
+        fileName: 'file:///workspace/src/App.tsx',
+        kind: ts.ScriptElementKind.functionElement,
+        name: 'App',
+        textSpan: {
+          length: 3,
+          start: 24,
+        },
+      },
+    ],
+    fs,
+    readFile,
+  )
+
+  expect(readFile).toHaveBeenCalledWith('file:///workspace/src/App.tsx')
+  expect(definition).toEqual({
+    endColumnIndex: 27,
+    endOffset: 27,
+    endRowIndex: 0,
+    startColumnIndex: 24,
+    startOffset: 24,
+    startRowIndex: 0,
+    uri: 'file:///workspace/src/App.tsx',
+  })
+})
+
+test('returns undefined when TypeScript finds no definition', async () => {
+  const fs = createFileSystem()
+  const readFile = jest.fn<(uri: string) => Promise<string>>()
+
+  expect(await getDefinitionFromTsResult2([], fs, readFile)).toBeUndefined()
+  expect(readFile).not.toHaveBeenCalled()
+})

--- a/packages/typescript-worker/test/GetOrCreateLanguageService.test.ts
+++ b/packages/typescript-worker/test/GetOrCreateLanguageService.test.ts
@@ -1,0 +1,46 @@
+import { expect, jest, test } from '@jest/globals'
+
+const createTypeScriptLanguageService = jest.fn(() => ({
+  getProgram: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/CreateTypeScriptLanguageService/CreateTypeScriptLanguageService.ts', () => ({
+  createTypeScriptLanguageService,
+}))
+
+jest.unstable_mockModule('../src/parts/GetTsconfigPath/GetTsconfigPath.ts', () => ({
+  getTsConfigPath: jest.fn(() => '/workspace/tsconfig.json'),
+}))
+
+jest.unstable_mockModule('../src/parts/LanguageServices/LanguageServices.ts', () => ({
+  get: jest.fn(() => ({
+    client: {
+      invokeSync: jest.fn(),
+    },
+    fs: {},
+    ts: {},
+  })),
+}))
+
+jest.unstable_mockModule('../src/parts/ParseTsconfig/ParseTsconfig.ts', () => ({
+  parseTsconfig: jest.fn(() => ({})),
+}))
+
+jest.unstable_mockModule('../src/parts/ResolveTsconfig/ResolveTsconfig.ts', () => ({
+  resolveTsconfig: jest.fn(() => ({
+    errors: [],
+    fileNames: ['/workspace/src/main.tsx', '/workspace/src/App.tsx'],
+    options: {},
+  })),
+}))
+
+const { getOrCreateLanguageService } =
+  await import('../src/parts/GetOrCreateLanguageService/GetOrCreateLanguageService.ts')
+
+test('reuses a language service for files in the same configured project', () => {
+  const first = getOrCreateLanguageService('/workspace/src/main.tsx')
+  const second = getOrCreateLanguageService('/workspace/src/App.tsx')
+
+  expect(second.languageService).toBe(first.languageService)
+  expect(createTypeScriptLanguageService).toHaveBeenCalledTimes(1)
+})

--- a/packages/typescript-worker/test/GetReferencesFromTsResult2.test.ts
+++ b/packages/typescript-worker/test/GetReferencesFromTsResult2.test.ts
@@ -1,0 +1,34 @@
+import { expect, jest, test } from '@jest/globals'
+import { createFileSystem } from '../src/parts/CreateFileSystem/CreateFileSystem.ts'
+import { getReferencesFromTsResult2 } from '../src/parts/GetReferencesFromTsResult2/GetReferencesFromTsResult2.ts'
+
+test('loads files that are not present in the in-memory file system', async () => {
+  const fs = createFileSystem()
+  const readFile = jest.fn<(uri: string) => Promise<string>>(async () => 'export default function App() {}')
+
+  const references = await getReferencesFromTsResult2(
+    [
+      {
+        fileName: 'file:///workspace/src/App.tsx',
+        isWriteAccess: false,
+        textSpan: {
+          length: 3,
+          start: 24,
+        },
+      },
+    ],
+    fs,
+    readFile,
+  )
+
+  expect(readFile).toHaveBeenCalledWith('file:///workspace/src/App.tsx')
+  expect(references).toEqual([
+    {
+      endColumnIndex: 27,
+      endRowIndex: 0,
+      startColumnIndex: 24,
+      startRowIndex: 0,
+      uri: 'file:///workspace/src/App.tsx',
+    },
+  ])
+})

--- a/packages/typescript-worker/test/ParseTsconfig.test.ts
+++ b/packages/typescript-worker/test/ParseTsconfig.test.ts
@@ -1,0 +1,26 @@
+import { expect, jest, test } from '@jest/globals'
+import * as TypeScript from 'typescript'
+import { parseTsconfig } from '../src/parts/ParseTsconfig/ParseTsconfig.ts'
+
+test('parses comments supported by tsconfig files', () => {
+  const readFile = jest.fn(() => {
+    return `{
+      "compilerOptions": {
+        /* Bundler mode */
+        "jsx": "react-jsx",
+      },
+    }`
+  })
+
+  expect(parseTsconfig('file:///workspace/tsconfig.json', readFile, TypeScript)).toEqual({
+    compilerOptions: {
+      jsx: 'react-jsx',
+    },
+  })
+})
+
+test('returns an empty config when parsing fails', () => {
+  const readFile = jest.fn(() => '{')
+
+  expect(parseTsconfig('file:///workspace/tsconfig.json', readFile, TypeScript)).toEqual({})
+})

--- a/packages/typescript-worker/test/WaitForSyncRpcResultBuffer.test.ts
+++ b/packages/typescript-worker/test/WaitForSyncRpcResultBuffer.test.ts
@@ -19,7 +19,7 @@ test('waitForSyncRpcResultBuffer - ok result', () => {
   Atomics.wait = originalAtomicsWait
 })
 
-test('waitForSyncRpcResultBuffer - not-equal result', () => {
+test('waitForSyncRpcResultBuffer - response arrived before waiting', () => {
   const maxWaitTime = 1000
   const sharedBuffer = new Int32Array(1)
 
@@ -29,7 +29,7 @@ test('waitForSyncRpcResultBuffer - not-equal result', () => {
 
   const result = WaitForSyncRpcResultBuffer.waitForSyncRpcResultBuffer(maxWaitTime, sharedBuffer)
 
-  expect(result).toBe(WaitForSyncBufferResultType.NotEqual)
+  expect(result).toBe(WaitForSyncBufferResultType.Ok)
   expect(Atomics.wait).toHaveBeenCalledWith(sharedBuffer, 0, 0, maxWaitTime)
 
   // Restore original function


### PR DESCRIPTION
Fix synchronous filesystem race handling, commented tsconfig parsing, declaration-module fallback resolution, project reuse, and path identity. Definition and reference results now load target files and return accurate cross-file positions. Verified against kinsta/hello-world-react-vite: hover works, F12 opens App.tsx, and references show 3 correct results across 2 files. Unit suite: 218 passed. Headless e2e: 103 passed, 11 skipped; the only old assertion was updated from file start to the correct same-file symbol column.