### PR TITLE
fix: resolve installed TypeScript declarations

### DIFF
--- a/packages/typescript-worker/src/parts/CreateModuleResolver/CreateModuleResolver.ts
+++ b/packages/typescript-worker/src/parts/CreateModuleResolver/CreateModuleResolver.ts
@@ -1,3 +1,4 @@
+import type * as TypeScript from 'typescript'
 import type { CompilerOptions, ResolvedModuleWithFailedLookupLocations } from 'typescript'
 import type { ModuleResolver } from '../ModuleResolver/ModuleResolver.ts'
 import type { SyncRpc } from '../SyncRpc/SyncRpc.ts'
@@ -111,6 +112,34 @@ const resolveModuleNameRelative = (
   }
 }
 
+const resolveRelativeDirectoryIndex = (
+  syncRpc: Readonly<SyncRpc>,
+  containingFile: string,
+  text: string,
+): ResolvedModuleWithFailedLookupLocations => {
+  const resolvedFileName = resolveRelativePath(containingFile, `${text}index.d.ts`)
+  try {
+    if (!syncRpc.invokeSync('SyncApi.exists', resolvedFileName)) {
+      return {
+        resolvedModule: undefined,
+      }
+    }
+  } catch {
+    return {
+      resolvedModule: undefined,
+    }
+  }
+  return {
+    resolvedModule: {
+      extension: '.d.ts',
+      isExternalLibraryImport: containingFile.includes('/node_modules/'),
+      packageId: undefined,
+      resolvedFileName,
+      resolvedUsingTsExtension: false,
+    },
+  }
+}
+
 const getNodeModulesLocation = (text: string): string => {
   // TODO check that node types are in the compilerOptions, only then resolve them
   if (isNode(text)) {
@@ -173,12 +202,64 @@ const resolveModuleNodeModules = (
   }
 }
 
-export const createModuleResolver = (syncRpc: Readonly<SyncRpc>): ModuleResolver => {
+const createModuleResolutionHost = (syncRpc: Readonly<SyncRpc>): TypeScript.ModuleResolutionHost => {
+  const exists = (path: string): boolean => {
+    try {
+      return Boolean(syncRpc.invokeSync('SyncApi.exists', path))
+    } catch {
+      return false
+    }
+  }
+  return {
+    directoryExists: exists,
+    fileExists: exists,
+    readFile(path) {
+      try {
+        return syncRpc.invokeSync('SyncApi.readFileSync', path)
+      } catch {
+        return undefined
+      }
+    },
+    realpath(path) {
+      return path
+    },
+  }
+}
+
+const resolveModuleNameWithTypeScript = (
+  ts: typeof TypeScript,
+  host: TypeScript.ModuleResolutionHost,
+  text: string,
+  containingFile: string,
+  compilerOptions: CompilerOptions,
+): ResolvedModuleWithFailedLookupLocations => {
+  if (containingFile.startsWith('file://')) {
+    return {
+      resolvedModule: undefined,
+    }
+  }
+  return ts.resolveModuleName(text, containingFile, compilerOptions, host)
+}
+
+export const createModuleResolver = (syncRpc: Readonly<SyncRpc>, ts?: typeof TypeScript): ModuleResolver => {
+  const moduleResolutionHost = ts ? createModuleResolutionHost(syncRpc) : undefined
   const resolveModuleName = (
     text: string,
     containingFile: string,
-    _compilerOptions: CompilerOptions,
+    compilerOptions: CompilerOptions,
   ): ResolvedModuleWithFailedLookupLocations => {
+    if (ts && moduleResolutionHost) {
+      const result = resolveModuleNameWithTypeScript(ts, moduleResolutionHost, text, containingFile, compilerOptions)
+      if (result.resolvedModule) {
+        return result
+      }
+      if ((text.startsWith('./') || text.startsWith('../')) && text.endsWith('/')) {
+        const directoryIndexResult = resolveRelativeDirectoryIndex(syncRpc, containingFile, text)
+        if (directoryIndexResult.resolvedModule) {
+          return directoryIndexResult
+        }
+      }
+    }
     if (!isFullySpecified(text)) {
       return {
         resolvedModule: undefined,

--- a/packages/typescript-worker/src/parts/TypeScriptLanguageHost/TypeScriptLanguageHost.ts
+++ b/packages/typescript-worker/src/parts/TypeScriptLanguageHost/TypeScriptLanguageHost.ts
@@ -43,7 +43,7 @@ export const create = (
   syncRpc: SyncRpc,
   options: TypeScript.ParsedCommandLine,
 ): ILanguageServiceHost => {
-  const resolveModuleName = createModuleResolver(syncRpc)
+  const resolveModuleName = createModuleResolver(syncRpc, ts)
   const languageServiceHost: ILanguageServiceHost = {
     directoryExists(directoryName) {
       if (doesSurelyNotExist(directoryName)) {

--- a/packages/typescript-worker/test/CreateModuleResolver.test.ts
+++ b/packages/typescript-worker/test/CreateModuleResolver.test.ts
@@ -514,3 +514,104 @@ test('createModuleResolver should handle null package.json', () => {
 
   expect(result.resolvedModule).toBeUndefined()
 })
+
+const createWorkspaceSyncRpc = (files: Readonly<Record<string, string>>) => {
+  const existingPaths = new Set(Object.keys(files))
+  for (const fileName of Object.keys(files)) {
+    let path = fileName
+    while (path.includes('/')) {
+      path = path.slice(0, path.lastIndexOf('/'))
+      existingPaths.add(path)
+    }
+  }
+  return {
+    invokeSync(method: string, path: string) {
+      if (method === 'SyncApi.exists') {
+        return existingPaths.has(path)
+      }
+      if (method === 'SyncApi.readFileSync') {
+        return files[path] || ''
+      }
+      throw new Error(`unexpected method ${method}`)
+    },
+  }
+}
+
+const bundlerOptions = {
+  jsx: TypeScript.JsxEmit.ReactJSX,
+  module: TypeScript.ModuleKind.ESNext,
+  moduleResolution: TypeScript.ModuleResolutionKind.Bundler,
+}
+
+test('createModuleResolver should prefer installed React declarations over the runtime JavaScript entrypoint', () => {
+  const syncRpc = createWorkspaceSyncRpc({
+    '/project/node_modules/@types/react/index.d.ts': 'export = React',
+    '/project/node_modules/@types/react/package.json': JSON.stringify({ types: 'index.d.ts' }),
+    '/project/node_modules/react/index.js': 'module.exports = {}',
+    '/project/node_modules/react/package.json': JSON.stringify({ main: 'index.js' }),
+    '/project/src/main.tsx': "import React from 'react'",
+  })
+  const resolver = createModuleResolver(syncRpc, TypeScript)
+
+  const result = resolver('react', '/project/src/main.tsx', bundlerOptions)
+
+  expect(result.resolvedModule?.extension).toBe('.d.ts')
+  expect(result.resolvedModule?.resolvedFileName).toBe('/project/node_modules/@types/react/index.d.ts')
+})
+
+test('createModuleResolver should resolve React declaration subpaths', () => {
+  const syncRpc = createWorkspaceSyncRpc({
+    '/project/node_modules/@types/react-dom/client.d.ts': "import React = require('react')",
+    '/project/node_modules/@types/react-dom/index.d.ts': 'export as namespace ReactDOM',
+    '/project/node_modules/@types/react-dom/package.json': JSON.stringify({ types: 'index.d.ts' }),
+    '/project/node_modules/react-dom/client.js': 'module.exports = {}',
+    '/project/node_modules/react-dom/package.json': JSON.stringify({
+      exports: {
+        './client': './client.js',
+      },
+      main: 'index.js',
+    }),
+    '/project/src/main.tsx': "import ReactDOM from 'react-dom/client'",
+  })
+  const resolver = createModuleResolver(syncRpc, TypeScript)
+
+  const result = resolver('react-dom/client', '/project/src/main.tsx', bundlerOptions)
+
+  expect(result.resolvedModule?.extension).toBe('.d.ts')
+  expect(result.resolvedModule?.resolvedFileName).toBe('/project/node_modules/@types/react-dom/client.d.ts')
+})
+
+test('createModuleResolver should resolve the automatic React JSX runtime declarations', () => {
+  const syncRpc = createWorkspaceSyncRpc({
+    '/project/node_modules/@types/react/index.d.ts': 'export = React',
+    '/project/node_modules/@types/react/jsx-runtime.d.ts': "import './'",
+    '/project/node_modules/@types/react/package.json': JSON.stringify({ types: 'index.d.ts' }),
+    '/project/node_modules/react/jsx-runtime.js': 'module.exports = {}',
+    '/project/node_modules/react/package.json': JSON.stringify({
+      exports: {
+        './jsx-runtime': './jsx-runtime.js',
+      },
+      main: 'index.js',
+    }),
+    '/project/src/App.tsx': 'export const App = () => <main />',
+  })
+  const resolver = createModuleResolver(syncRpc, TypeScript)
+
+  const result = resolver('react/jsx-runtime', '/project/src/App.tsx', bundlerOptions)
+
+  expect(result.resolvedModule?.extension).toBe('.d.ts')
+  expect(result.resolvedModule?.resolvedFileName).toBe('/project/node_modules/@types/react/jsx-runtime.d.ts')
+})
+
+test('createModuleResolver should resolve declaration package directory imports', () => {
+  const syncRpc = createWorkspaceSyncRpc({
+    '/project/node_modules/@types/react/index.d.ts': 'export = React',
+    '/project/node_modules/@types/react/jsx-runtime.d.ts': "import './'",
+  })
+  const resolver = createModuleResolver(syncRpc, TypeScript)
+
+  const result = resolver('./', '/project/node_modules/@types/react/jsx-runtime.d.ts', bundlerOptions)
+
+  expect(result.resolvedModule?.extension).toBe('.d.ts')
+  expect(result.resolvedModule?.resolvedFileName).toBe('/project/node_modules/@types/react/index.d.ts')
+})

--- a/packages/typescript-worker/test/TypeScriptLanguageHost.test.ts
+++ b/packages/typescript-worker/test/TypeScriptLanguageHost.test.ts
@@ -419,6 +419,87 @@ test('default project should report JavaScript diagnostics', () => {
   expect(languageService.getSemanticDiagnostics(uri).map((diagnostic) => diagnostic.code)).toContain(2356)
 })
 
+test('React TSX project should use installed JSX declarations', () => {
+  const uri = '/project/src/App.tsx'
+  const files: Readonly<Record<string, string>> = {
+    '/project/node_modules/@types/react/global.d.ts':
+      'declare namespace JSX { interface IntrinsicElements { main: Record<string, unknown> } }',
+    '/project/node_modules/@types/react/index.d.ts':
+      "/// <reference path='global.d.ts' />\nexport = React\ndeclare namespace React {}",
+    '/project/node_modules/@types/react/jsx-runtime.d.ts': "import './'",
+    '/project/node_modules/@types/react/package.json': JSON.stringify({
+      exports: {
+        '.': {
+          types: {
+            default: './index.d.ts',
+          },
+        },
+        './jsx-runtime': {
+          types: {
+            default: './jsx-runtime.d.ts',
+          },
+        },
+      },
+      name: '@types/react',
+      types: 'index.d.ts',
+      version: '18.2.0',
+    }),
+    '/project/node_modules/react/jsx-runtime.js': 'module.exports = {}',
+    '/project/node_modules/react/package.json': JSON.stringify({
+      exports: {
+        './jsx-runtime': './jsx-runtime.js',
+      },
+      main: 'index.js',
+    }),
+  }
+  const existingPaths = new Set(Object.keys(files))
+  for (const fileName of Object.keys(files)) {
+    let path = fileName
+    while (path.includes('/')) {
+      path = path.slice(0, path.lastIndexOf('/'))
+      existingPaths.add(path)
+    }
+  }
+  const syncRpc = {
+    invokeSync(method: string, path: string) {
+      if (method === 'SyncApi.exists') {
+        return existingPaths.has(path)
+      }
+      if (method === 'SyncApi.readDirSync') {
+        return []
+      }
+      if (method === 'SyncApi.readFileSync') {
+        return files[path] || ''
+      }
+      throw new Error(`unexpected method ${method}`)
+    },
+  }
+  const fileSystem = createFileSystem()
+  fileSystem.writeFile(uri, 'export const App = () => <main />')
+  const host = create(TypeScript, fileSystem, syncRpc, {
+    errors: [],
+    fileNames: [uri],
+    options: {
+      jsx: TypeScript.JsxEmit.ReactJSX,
+      module: TypeScript.ModuleKind.ESNext,
+      moduleResolution: TypeScript.ModuleResolutionKind.Bundler,
+      noLib: true,
+      rootDir: '/project',
+      skipLibCheck: true,
+      strict: true,
+    },
+  })
+  const languageService = TypeScript.createLanguageService(host)
+  const sourceFileNames = languageService
+    .getProgram()
+    ?.getSourceFiles()
+    .map((sourceFile) => sourceFile.fileName)
+
+  expect(sourceFileNames).toContain('/project/node_modules/@types/react/index.d.ts')
+  expect(sourceFileNames).toContain('/project/node_modules/@types/react/global.d.ts')
+  expect(languageService.getSemanticDiagnostics(uri)).toEqual([])
+})
+
 test('writeFile should throw error', () => {
   globalThis.rpc = {
     invoke: jest.fn(() => Promise.resolve()),


### PR DESCRIPTION
## Summary

- delegate workspace module resolution to the bundled TypeScript resolver
- preserve the URI-aware resolver as a fallback and handle declaration package directory imports
- cover React, React DOM subpaths, automatic JSX runtime declarations, and a TSX language-host integration

## Validation

- `npm test` (223 passed, 9 skipped)
- `npm run type-check`
- `npm run lint`
- `npm run build`
- `npm run e2e:headless` (104 passed, 11 skipped)
- browser-tested `kinsta/hello-world-react-vite` at `7860b331c97d`: zero squiggle/error decorations in `App.tsx` and `main.tsx`
- fixture `npx tsc --noEmit`