### PR TITLE
feature: add TypeScript signature help

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "typescript": "^6.0.3"
       },
       "devDependencies": {
-        "@lvce-editor/api": "^8.53.1",
+        "@lvce-editor/api": "^8.73.0",
         "@lvce-editor/eslint-config": "^17.5.0",
         "eslint": "^10.8.0",
         "jest": "^30.4.2",
@@ -2602,9 +2602,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/api": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.53.1.tgz",
-      "integrity": "sha512-dOsMEPbfUhd0TnmWTzm7Eu1WPx8Vq4RjR7XQ801B7zAr8n5sOElyqb9hbonadIkQoLX2h7OG+KqE3XMqElm4Vg==",
+      "version": "8.73.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.73.0.tgz",
+      "integrity": "sha512-gaXMFv0s+8/om6VckoP1QmuwJvG2+q2xCDT5E0ryHrnAaxoQ3bQJ5TgcMQenTLYICw+KZH4EwnvBdAfmDO/iPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14454,20 +14454,10 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/api": "^8.45.0",
+        "@lvce-editor/api": "^8.73.0",
+        "@lvce-editor/rpc": "^6.8.0",
+        "@lvce-editor/rpc-registry": "^9.36.0",
         "typescript": "^6.0.3"
-      }
-    },
-    "packages/extension/node_modules/@lvce-editor/api": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.45.0.tgz",
-      "integrity": "sha512-J+yCMJlv1zjKObFBWe4Soc35N7JjJWBa8zK4Dza+0u6F+DvxoPF2yhcGtB5EkgjVuOuWD9t72CdDGVCPyYv/KA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/rpc": "^6.4.0",
-        "@lvce-editor/rpc-registry": "^9.24.0",
-        "@lvce-editor/virtual-dom-worker": "^10.0.0"
       }
     },
     "packages/server": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "typescript": "^6.0.3"
   },
   "devDependencies": {
-    "@lvce-editor/api": "^8.53.1",
+    "@lvce-editor/api": "^8.73.0",
     "@lvce-editor/eslint-config": "^17.5.0",
     "eslint": "^10.8.0",
     "jest": "^30.4.2",

--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -35,6 +35,9 @@
     "onHover:javascript",
     "onHover:typescript",
     "onHover:typescriptreact",
+    "onSignatureHelp:javascript",
+    "onSignatureHelp:typescript",
+    "onSignatureHelp:typescriptreact",
     "onTabCompletion:javascript",
     "onTabCompletion:typescript"
   ],
@@ -52,6 +55,11 @@
     { "id": "typescript.provideHover.javascript", "languageId": "javascript" },
     { "id": "typescript.provideHover.typescript", "languageId": "typescript" },
     { "id": "typescript.provideHover.typescriptreact", "languageId": "typescriptreact" }
+  ],
+  "signatureHelpProviders": [
+    { "id": "typescript.provideSignatureHelp.javascript", "languageId": "javascript" },
+    { "id": "typescript.provideSignatureHelp.typescript", "languageId": "typescript" },
+    { "id": "typescript.provideSignatureHelp.typescriptreact", "languageId": "typescriptreact" }
   ],
   "languages": [
     {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -28,7 +28,9 @@
     }
   },
   "devDependencies": {
-    "@lvce-editor/api": "^8.45.0",
+    "@lvce-editor/api": "^8.73.0",
+    "@lvce-editor/rpc": "^6.8.0",
+    "@lvce-editor/rpc-registry": "^9.36.0",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/extension/src/parts/ExtensionHost/ExtensionHostSignatureHelpProviderTypeScript.ts
+++ b/packages/extension/src/parts/ExtensionHost/ExtensionHostSignatureHelpProviderTypeScript.ts
@@ -1,0 +1,9 @@
+import * as LanguageId from '../LanguageId/LanguageId.ts'
+import * as TypeScriptWorker from '../TypeScriptWorker/TypeScriptWorker.ts'
+
+export const languageId = LanguageId.TypeScript
+
+export const provideSignatureHelp = async (textDocument: any, offset: number): Promise<any> => {
+  const worker = await TypeScriptWorker.getInstance()
+  return worker.invoke('SignatureHelp.getSignatureHelp', textDocument, offset)
+}

--- a/packages/extension/src/parts/LaunchWorker/LaunchWorker.ts
+++ b/packages/extension/src/parts/LaunchWorker/LaunchWorker.ts
@@ -1,11 +1,14 @@
-import { createRpc } from '@lvce-editor/api'
+import { LazyTransferMessagePortRpcParent } from '@lvce-editor/rpc'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import * as Command from '../Command/Command.ts'
 
 export const launchWorker = async ({ name, url }: { name: string; url: string }): Promise<any> => {
-  const rpc = await createRpc({
+  const rpc = await LazyTransferMessagePortRpcParent.create({
     commandMap: Command.commandMap,
-    name,
-    url,
+    send(port): Promise<void> {
+      return ExtensionManagementWorker.invokeAndTransfer('Extensions.createWebViewWorkerRpc', { name }, port)
+    },
   })
+  await rpc.invoke('LoadFile.loadFile', url)
   return rpc
 }

--- a/packages/extension/src/parts/Providers/Providers.ts
+++ b/packages/extension/src/parts/Providers/Providers.ts
@@ -9,5 +9,6 @@ export * as ImplementationProvider from '../ExtensionHost/ExtensionHostImplement
 export * as ReferenceProvider from '../ExtensionHost/ExtensionHostReferenceProviderTypeScript.ts'
 export * as RenameProvider from '../ExtensionHost/ExtensionHostRenameProviderTypeScript.ts'
 export * as Selection from '../ExtensionHost/ExtensionHostSelectionProviderTypeScript.ts'
+export * as SignatureHelpProvider from '../ExtensionHost/ExtensionHostSignatureHelpProviderTypeScript.ts'
 export * as TabCompletionProvider from '../ExtensionHost/ExtensionHostTabCompletionProviderTypeScript.ts'
 export * as TypeDefinitionProvider from '../ExtensionHost/ExtensionHostTypeDefinitionProviderTypeScript.ts'

--- a/packages/extension/src/parts/RegisterProviders/RegisterProviders.ts
+++ b/packages/extension/src/parts/RegisterProviders/RegisterProviders.ts
@@ -11,6 +11,7 @@ import {
   registerReferenceProvider,
   registerRenameProvider,
   registerSelectionProvider,
+  registerSignatureHelpProvider,
   registerTabCompletionProvider,
   registerTypeDefinitionProvider,
 } from '@lvce-editor/api'
@@ -47,6 +48,10 @@ const registerProvider = (provider: any): void => {
   }
   if ('provideHover' in provider) {
     registerHoverProvider(provider)
+    return
+  }
+  if ('provideSignatureHelp' in provider) {
+    registerSignatureHelpProvider(provider)
     return
   }
   if ('provideTabCompletion' in provider) {

--- a/packages/typescript-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/typescript-worker/src/parts/CommandMap/CommandMap.ts
@@ -11,6 +11,7 @@ import * as References from '../References/References.ts'
 import * as Rename from '../Rename/Rename.ts'
 import * as ResolveCompletion from '../ResolveCompletion/ResolveCompletion.ts'
 import * as Selection from '../Selection/Selection.ts'
+import * as SignatureHelp from '../SignatureHelp/SignatureHelp.ts'
 import * as WrapCommand from '../WrapCommand/WrapCommand.ts'
 
 export const commandMap = {
@@ -29,4 +30,5 @@ export const commandMap = {
   'References.provideReferences2': References.provideReferences2,
   'Rename.rename': WrapCommand.wrapCommand(Rename.rename),
   'Selection.expandSelections': WrapCommand.wrapCommand(Selection.expandSelection),
+  'SignatureHelp.getSignatureHelp': WrapCommand.wrapCommand(SignatureHelp.getSignatureHelp),
 }

--- a/packages/typescript-worker/src/parts/GetSignatureHelpFromTsResult/GetSignatureHelpFromTsResult.ts
+++ b/packages/typescript-worker/src/parts/GetSignatureHelpFromTsResult/GetSignatureHelpFromTsResult.ts
@@ -1,0 +1,30 @@
+import type ts from 'typescript'
+
+const displayPartsToString = (parts: readonly ts.SymbolDisplayPart[]): string => {
+  return parts.map((part) => part.text).join('')
+}
+
+export const getSignatureHelpFromTsResult = (result: ts.SignatureHelpItems | undefined) => {
+  if (!result) {
+    return undefined
+  }
+  return {
+    activeParameter: result.argumentIndex,
+    activeSignature: result.selectedItemIndex,
+    signatures: result.items.map((item) => {
+      const separator = displayPartsToString(item.separatorDisplayParts)
+      const parameters = item.parameters.map((parameter) => ({
+        documentation: displayPartsToString(parameter.documentation),
+        label: displayPartsToString(parameter.displayParts),
+      }))
+      return {
+        documentation: displayPartsToString(item.documentation),
+        label:
+          displayPartsToString(item.prefixDisplayParts) +
+          parameters.map((parameter) => parameter.label).join(separator) +
+          displayPartsToString(item.suffixDisplayParts),
+        parameters,
+      }
+    }),
+  }
+}

--- a/packages/typescript-worker/src/parts/SignatureHelp/SignatureHelp.ts
+++ b/packages/typescript-worker/src/parts/SignatureHelp/SignatureHelp.ts
@@ -1,0 +1,10 @@
+import type { CommonRpc } from '../CommonRpc/CommonRpc.ts'
+import * as Assert from '../Assert/Assert.ts'
+import { getSignatureHelp2 } from '../SignatureHelp2/SignatureHelp2.ts'
+
+export const getSignatureHelp = async (typescriptRpc: CommonRpc, Position: any, textDocument: any, offset: number) => {
+  const { uri } = textDocument
+  Assert.string(uri)
+  Assert.number(offset)
+  return getSignatureHelp2(textDocument, offset)
+}

--- a/packages/typescript-worker/src/parts/SignatureHelp2/SignatureHelp2.ts
+++ b/packages/typescript-worker/src/parts/SignatureHelp2/SignatureHelp2.ts
@@ -1,0 +1,9 @@
+import { getOrCreateLanguageService } from '../GetOrCreateLanguageService/GetOrCreateLanguageService.ts'
+import { getSignatureHelpFromTsResult } from '../GetSignatureHelpFromTsResult/GetSignatureHelpFromTsResult.ts'
+
+export const getSignatureHelp2 = async (textDocument: any, offset: number) => {
+  const { fs, languageService } = getOrCreateLanguageService(textDocument.uri)
+  fs.writeFile(textDocument.uri, textDocument.text)
+  const result = languageService.getSignatureHelpItems(textDocument.uri, offset, undefined)
+  return getSignatureHelpFromTsResult(result)
+}

--- a/packages/typescript-worker/test/GetSignatureHelpFromTsResult.test.ts
+++ b/packages/typescript-worker/test/GetSignatureHelpFromTsResult.test.ts
@@ -1,0 +1,64 @@
+import type ts from 'typescript'
+import { expect, test } from '@jest/globals'
+import { getSignatureHelpFromTsResult } from '../src/parts/GetSignatureHelpFromTsResult/GetSignatureHelpFromTsResult.ts'
+
+test('getSignatureHelpFromTsResult converts TypeScript signature help', () => {
+  const result: ts.SignatureHelpItems = {
+    applicableSpan: {
+      length: 4,
+      start: 0,
+    },
+    argumentCount: 2,
+    argumentIndex: 1,
+    items: [
+      {
+        documentation: [{ kind: 'text', text: 'Calls foo.' }],
+        isVariadic: false,
+        parameters: [
+          {
+            displayParts: [{ kind: 'parameterName', text: 'first: string' }],
+            documentation: [{ kind: 'text', text: 'First value.' }],
+            isOptional: false,
+            name: 'first',
+          },
+          {
+            displayParts: [{ kind: 'parameterName', text: 'second: number' }],
+            documentation: [{ kind: 'text', text: 'Second value.' }],
+            isOptional: false,
+            name: 'second',
+          },
+        ],
+        prefixDisplayParts: [{ kind: 'text', text: 'foo(' }],
+        separatorDisplayParts: [{ kind: 'text', text: ', ' }],
+        suffixDisplayParts: [{ kind: 'text', text: '): void' }],
+        tags: [],
+      },
+    ],
+    selectedItemIndex: 0,
+  }
+
+  expect(getSignatureHelpFromTsResult(result)).toEqual({
+    activeParameter: 1,
+    activeSignature: 0,
+    signatures: [
+      {
+        documentation: 'Calls foo.',
+        label: 'foo(first: string, second: number): void',
+        parameters: [
+          {
+            documentation: 'First value.',
+            label: 'first: string',
+          },
+          {
+            documentation: 'Second value.',
+            label: 'second: number',
+          },
+        ],
+      },
+    ],
+  })
+})
+
+test('getSignatureHelpFromTsResult returns undefined for no result', () => {
+  expect(getSignatureHelpFromTsResult(undefined)).toBeUndefined()
+})

--- a/packages/typescript-worker/test/SignatureHelp.test.ts
+++ b/packages/typescript-worker/test/SignatureHelp.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@jest/globals'
+import * as TypeScript from 'typescript'
+import { createFileSystem } from '../src/parts/CreateFileSystem/CreateFileSystem.ts'
+import * as LanguageServices from '../src/parts/LanguageServices/LanguageServices.ts'
+import { getSignatureHelp2 } from '../src/parts/SignatureHelp2/SignatureHelp2.ts'
+
+test('getSignatureHelp2 returns signature and active parameter from the language service', async () => {
+  const OriginalXmlHttpRequest = typeof XMLHttpRequest === 'undefined' ? undefined : XMLHttpRequest
+  Object.defineProperty(globalThis, 'XMLHttpRequest', {
+    configurable: true,
+    value: class {
+      readonly responseText = ''
+
+      open(): void {}
+
+      send(): void {}
+
+      setRequestHeader(): void {}
+    },
+  })
+  const fs = createFileSystem()
+  const client = {
+    invokeSync(method: string): any {
+      if (method === 'SyncApi.exists') {
+        return false
+      }
+      if (method === 'SyncApi.readDirSync') {
+        return []
+      }
+      if (method === 'SyncApi.readFileSync') {
+        return ''
+      }
+      throw new Error(`unexpected method ${method}`)
+    },
+  }
+  LanguageServices.set(1, fs, client, TypeScript)
+  const text = ['function greet(name: string, count: number): void {}', "greet('Ada', "].join('\n')
+  const textDocument = {
+    languageId: 'typescript',
+    text,
+    uri: '/signature-help-test.ts',
+  }
+
+  try {
+    const result = await getSignatureHelp2(textDocument, text.length)
+
+    expect(result?.activeParameter).toBe(1)
+    expect(result?.activeSignature).toBe(0)
+    expect(result?.signatures).toHaveLength(1)
+    expect(result?.signatures[0].label).toBe('greet(name: string, count: number): void')
+    expect(result?.signatures[0].parameters.map((parameter) => parameter.label)).toEqual([
+      'name: string',
+      'count: number',
+    ])
+  } finally {
+    Object.defineProperty(globalThis, 'XMLHttpRequest', {
+      configurable: true,
+      value: OriginalXmlHttpRequest,
+    })
+  }
+})


### PR DESCRIPTION
## Summary
- register isolated signature help providers for JavaScript, TypeScript, and TSX
- request signature help from the TypeScript language service and convert overload/parameter metadata
- update the extension API dependency and keep TypeScript subworker startup compatible with older and current hosts

## Testing
- npm test -- --runInBand (226 passed, 9 skipped)
- language-service integration test covers selected signature and active parameter
- npm run e2e:headless (104 passed, 11 skipped)
- npm run type-check
- npm run lint
- npm run build