### PR TITLE
fix: resolve CommonJS directory entrypoints

### DIFF
--- a/packages/e2e/fixtures/diagnostics-commonjs-directory-main/node_modules/commonjs-directory-main/package.json
+++ b/packages/e2e/fixtures/diagnostics-commonjs-directory-main/node_modules/commonjs-directory-main/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "commonjs-directory-main",
+  "version": "1.0.0",
+  "main": "source"
+}

--- a/packages/e2e/fixtures/diagnostics-commonjs-directory-main/node_modules/commonjs-directory-main/source/index.js
+++ b/packages/e2e/fixtures/diagnostics-commonjs-directory-main/node_modules/commonjs-directory-main/source/index.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/packages/e2e/fixtures/diagnostics-commonjs-directory-main/package.json
+++ b/packages/e2e/fixtures/diagnostics-commonjs-directory-main/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "diagnostics-commonjs-directory-main",
+  "version": "1.0.0",
+  "type": "module"
+}

--- a/packages/e2e/fixtures/diagnostics-commonjs-directory-main/src/main.ts
+++ b/packages/e2e/fixtures/diagnostics-commonjs-directory-main/src/main.ts
@@ -1,0 +1,3 @@
+import 'commonjs-directory-main'
+
+let x: string = 1

--- a/packages/e2e/fixtures/diagnostics-commonjs-directory-main/tsconfig.json
+++ b/packages/e2e/fixtures/diagnostics-commonjs-directory-main/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": []
+  }
+}

--- a/packages/e2e/src/typescript.diagnostics-commonjs-directory-main.ts
+++ b/packages/e2e/src/typescript.diagnostics-commonjs-directory-main.ts
@@ -1,0 +1,31 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-commonjs-directory-main'
+
+export const test: Test = async ({ Editor, FileSystem, Main, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics-commonjs-directory-main')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  const uri = `${workspaceUrl}/src/main.ts`
+  await Main.openUri(uri)
+
+  // assert
+  const expectedDiagnostics = [
+    {
+      code: 2322,
+      columnIndex: 4,
+      endColumnIndex: 5,
+      endRowIndex: 2,
+      message: "Type 'number' is not assignable to type 'string'.",
+      rowIndex: 2,
+      source: 'ts',
+      type: 'error',
+      uri,
+    },
+  ] as const
+  await Editor.shouldHaveDiagnostics(expectedDiagnostics)
+}

--- a/packages/typescript-worker/src/parts/CreateModuleResolver/CreateModuleResolver.ts
+++ b/packages/typescript-worker/src/parts/CreateModuleResolver/CreateModuleResolver.ts
@@ -210,9 +210,17 @@ const createModuleResolutionHost = (syncRpc: Readonly<SyncRpc>): TypeScript.Modu
       return false
     }
   }
+  const fileExists = (path: string): boolean => {
+    try {
+      syncRpc.invokeSync('SyncApi.readFileSync', path)
+      return true
+    } catch {
+      return false
+    }
+  }
   return {
     directoryExists: exists,
-    fileExists: exists,
+    fileExists,
     readFile(path) {
       try {
         return syncRpc.invokeSync('SyncApi.readFileSync', path)

--- a/packages/typescript-worker/test/CreateModuleResolver.test.ts
+++ b/packages/typescript-worker/test/CreateModuleResolver.test.ts
@@ -530,7 +530,10 @@ const createWorkspaceSyncRpc = (files: Readonly<Record<string, string>>) => {
         return existingPaths.has(path)
       }
       if (method === 'SyncApi.readFileSync') {
-        return files[path] || ''
+        if (Object.hasOwn(files, path)) {
+          return files[path]
+        }
+        throw new Error('File not found')
       }
       throw new Error(`unexpected method ${method}`)
     },
@@ -614,4 +617,21 @@ test('createModuleResolver should resolve declaration package directory imports'
 
   expect(result.resolvedModule?.extension).toBe('.d.ts')
   expect(result.resolvedModule?.resolvedFileName).toBe('/project/node_modules/@types/react/index.d.ts')
+})
+
+test('createModuleResolver should resolve a CommonJS package whose main entry is a directory', () => {
+  const syncRpc = createWorkspaceSyncRpc({
+    '/project/node_modules/chalk/package.json': JSON.stringify({ main: 'source' }),
+    '/project/node_modules/chalk/source/index.js': 'module.exports = {}',
+    '/project/src/main.ts': "import chalk from 'chalk'",
+  })
+  const resolver = createModuleResolver(syncRpc, TypeScript)
+
+  const result = resolver('chalk', '/project/src/main.ts', {
+    module: TypeScript.ModuleKind.NodeNext,
+    moduleResolution: TypeScript.ModuleResolutionKind.NodeNext,
+  })
+
+  expect(result.resolvedModule?.extension).toBe('.js')
+  expect(result.resolvedModule?.resolvedFileName).toBe('/project/node_modules/chalk/source/index.js')
 })

--- a/packages/typescript-worker/test/TypeScriptLanguageHost.test.ts
+++ b/packages/typescript-worker/test/TypeScriptLanguageHost.test.ts
@@ -469,7 +469,10 @@ test('React TSX project should use installed JSX declarations', () => {
         return []
       }
       if (method === 'SyncApi.readFileSync') {
-        return files[path] || ''
+        if (Object.hasOwn(files, path)) {
+          return files[path]
+        }
+        throw new Error('File not found')
       }
       throw new Error(`unexpected method ${method}`)
     },


### PR DESCRIPTION
Fix TypeScript module resolution for CommonJS packages whose package.json main field points to a directory. File probes now distinguish files from directories so TypeScript can continue to the directory index entrypoint, with unit and diagnostics e2e regressions covering the Chalk-style package layout.