### PR TITLE
feature: add 50 more TypeScript e2e tests

### DIFF
--- a/packages/e2e/fixtures/diagnostics/src/abstract-member-concrete-class.ts
+++ b/packages/e2e/fixtures/diagnostics/src/abstract-member-concrete-class.ts
@@ -1,0 +1,7 @@
+export const fixture = true
+
+class Store {
+  abstract getValue(): number
+}
+
+export const store = Store

--- a/packages/e2e/fixtures/diagnostics/src/abstract-static-member.ts
+++ b/packages/e2e/fixtures/diagnostics/src/abstract-static-member.ts
@@ -1,0 +1,7 @@
+export const fixture = true
+
+abstract class Store {
+  static abstract getValue(): number
+}
+
+export const store = Store

--- a/packages/e2e/fixtures/diagnostics/src/accessor-type-parameters.ts
+++ b/packages/e2e/fixtures/diagnostics/src/accessor-type-parameters.ts
@@ -1,0 +1,9 @@
+export const fixture = true
+
+class Store {
+  get value<T>(): T {
+    return undefined as T
+  }
+}
+
+export const store = new Store()

--- a/packages/e2e/fixtures/diagnostics/src/async-return-type.ts
+++ b/packages/e2e/fixtures/diagnostics/src/async-return-type.ts
@@ -1,0 +1,5 @@
+export const fixture = true
+
+export async function getCount(): number {
+  return 1
+}

--- a/packages/e2e/fixtures/diagnostics/src/await-non-async.ts
+++ b/packages/e2e/fixtures/diagnostics/src/await-non-async.ts
@@ -1,0 +1,5 @@
+export const fixture = true
+
+export function load(): void {
+  await Promise.resolve()
+}

--- a/packages/e2e/fixtures/diagnostics/src/await-parameter-initializer.ts
+++ b/packages/e2e/fixtures/diagnostics/src/await-parameter-initializer.ts
@@ -1,0 +1,5 @@
+export const fixture = true
+
+export async function load(value = await Promise.resolve(1)): Promise<number> {
+  return value
+}

--- a/packages/e2e/fixtures/diagnostics/src/break-outside-loop.ts
+++ b/packages/e2e/fixtures/diagnostics/src/break-outside-loop.ts
@@ -1,0 +1,3 @@
+export const fixture = true
+
+break

--- a/packages/e2e/fixtures/diagnostics/src/catch-type-annotation.ts
+++ b/packages/e2e/fixtures/diagnostics/src/catch-type-annotation.ts
@@ -1,0 +1,5 @@
+export const fixture = true
+
+try {
+  throw new Error('failure')
+} catch (error: Error) {}

--- a/packages/e2e/fixtures/diagnostics/src/circular-type-parameter.ts
+++ b/packages/e2e/fixtures/diagnostics/src/circular-type-parameter.ts
@@ -1,0 +1,5 @@
+export const fixture = true
+
+type Value<Input extends Input> = Input
+
+export const value = {} as Value<string>

--- a/packages/e2e/fixtures/diagnostics/src/const-enum-non-constant.ts
+++ b/packages/e2e/fixtures/diagnostics/src/const-enum-non-constant.ts
@@ -1,0 +1,7 @@
+export const fixture = true
+
+const enum RandomValue {
+  Random = Math.random(),
+}
+
+export const value = RandomValue.Random

--- a/packages/e2e/fixtures/diagnostics/src/constructor-return-type.ts
+++ b/packages/e2e/fixtures/diagnostics/src/constructor-return-type.ts
@@ -1,0 +1,7 @@
+export const fixture = true
+
+class Store {
+  constructor(): Store {}
+}
+
+export const store = new Store()

--- a/packages/e2e/fixtures/diagnostics/src/constructor-type-parameters.ts
+++ b/packages/e2e/fixtures/diagnostics/src/constructor-type-parameters.ts
@@ -1,0 +1,7 @@
+export const fixture = true
+
+class Store {
+  constructor<T>() {}
+}
+
+export const store = new Store()

--- a/packages/e2e/fixtures/diagnostics/src/continue-outside-loop.ts
+++ b/packages/e2e/fixtures/diagnostics/src/continue-outside-loop.ts
@@ -1,0 +1,3 @@
+export const fixture = true
+
+continue

--- a/packages/e2e/fixtures/diagnostics/src/definite-assignment-initializer.ts
+++ b/packages/e2e/fixtures/diagnostics/src/definite-assignment-initializer.ts
@@ -1,0 +1,7 @@
+export const fixture = true
+
+class Store {
+  value!: number = 1
+}
+
+export const store = new Store()

--- a/packages/e2e/fixtures/diagnostics/src/duplicate-label.ts
+++ b/packages/e2e/fixtures/diagnostics/src/duplicate-label.ts
@@ -1,0 +1,6 @@
+export const fixture = true
+
+block: {
+  block: {
+  }
+}

--- a/packages/e2e/fixtures/diagnostics/src/extends-interface.ts
+++ b/packages/e2e/fixtures/diagnostics/src/extends-interface.ts
@@ -1,0 +1,7 @@
+export const fixture = true
+
+interface Base {}
+
+class Derived extends Base {}
+
+export const derived = Derived

--- a/packages/e2e/fixtures/diagnostics/src/function-return-type.ts
+++ b/packages/e2e/fixtures/diagnostics/src/function-return-type.ts
@@ -1,0 +1,3 @@
+export const fixture = true
+
+export const getCount = (): number => 'one'

--- a/packages/e2e/fixtures/diagnostics/src/generator-return-type.ts
+++ b/packages/e2e/fixtures/diagnostics/src/generator-return-type.ts
@@ -1,0 +1,5 @@
+export const fixture = true
+
+export function* values(): number {
+  yield 1
+}

--- a/packages/e2e/fixtures/diagnostics/src/getter-parameters.ts
+++ b/packages/e2e/fixtures/diagnostics/src/getter-parameters.ts
@@ -1,0 +1,9 @@
+export const fixture = true
+
+class Store {
+  get value(index: number): number {
+    return index
+  }
+}
+
+export const store = new Store()

--- a/packages/e2e/fixtures/diagnostics/src/implements-primitive.ts
+++ b/packages/e2e/fixtures/diagnostics/src/implements-primitive.ts
@@ -1,0 +1,5 @@
+export const fixture = true
+
+class Store implements string {}
+
+export const store = Store

--- a/packages/e2e/fixtures/diagnostics/src/in-operator-right.ts
+++ b/packages/e2e/fixtures/diagnostics/src/in-operator-right.ts
@@ -1,0 +1,3 @@
+export const fixture = true
+
+export const hasName = 'name' in 1

--- a/packages/e2e/fixtures/diagnostics/src/instanceof-left.ts
+++ b/packages/e2e/fixtures/diagnostics/src/instanceof-left.ts
@@ -1,0 +1,3 @@
+export const fixture = true
+
+export const matches = 1 instanceof Object

--- a/packages/e2e/fixtures/diagnostics/src/instanceof-right.ts
+++ b/packages/e2e/fixtures/diagnostics/src/instanceof-right.ts
@@ -1,0 +1,5 @@
+export const fixture = true
+
+const constructor = 1
+
+export const matches = {} instanceof constructor

--- a/packages/e2e/fixtures/diagnostics/src/interface-extends-primitive.ts
+++ b/packages/e2e/fixtures/diagnostics/src/interface-extends-primitive.ts
@@ -1,0 +1,5 @@
+export const fixture = true
+
+interface Store extends string {}
+
+export const store = {} as Store

--- a/packages/e2e/fixtures/diagnostics/src/invalid-break-label.ts
+++ b/packages/e2e/fixtures/diagnostics/src/invalid-break-label.ts
@@ -1,0 +1,5 @@
+export const fixture = true
+
+while (true) {
+  break missing
+}

--- a/packages/e2e/fixtures/diagnostics/src/invalid-continue-label.ts
+++ b/packages/e2e/fixtures/diagnostics/src/invalid-continue-label.ts
@@ -1,0 +1,5 @@
+export const fixture = true
+
+block: {
+  continue block
+}

--- a/packages/e2e/fixtures/diagnostics/src/missing-constructor-argument.ts
+++ b/packages/e2e/fixtures/diagnostics/src/missing-constructor-argument.ts
@@ -1,0 +1,7 @@
+export const fixture = true
+
+class Store {
+  constructor(value: string) {}
+}
+
+export const store = new Store()

--- a/packages/e2e/fixtures/diagnostics/src/missing-super-call.ts
+++ b/packages/e2e/fixtures/diagnostics/src/missing-super-call.ts
@@ -1,0 +1,9 @@
+export const fixture = true
+
+class Base {}
+
+class Derived extends Base {
+  constructor() {}
+}
+
+export const derived = Derived

--- a/packages/e2e/fixtures/diagnostics/src/new-target-outside-function.ts
+++ b/packages/e2e/fixtures/diagnostics/src/new-target-outside-function.ts
@@ -1,0 +1,3 @@
+export const fixture = true
+
+export const target = new.target

--- a/packages/e2e/fixtures/diagnostics/src/non-constructable.ts
+++ b/packages/e2e/fixtures/diagnostics/src/non-constructable.ts
@@ -1,0 +1,5 @@
+export const fixture = true
+
+const create = (): object => ({})
+
+export const result = new create()

--- a/packages/e2e/fixtures/diagnostics/src/optional-parameter-initializer.ts
+++ b/packages/e2e/fixtures/diagnostics/src/optional-parameter-initializer.ts
@@ -1,0 +1,3 @@
+export const fixture = true
+
+export const format = (value?: string = 'default'): string => value

--- a/packages/e2e/fixtures/diagnostics/src/overload-implementation-missing.ts
+++ b/packages/e2e/fixtures/diagnostics/src/overload-implementation-missing.ts
@@ -1,0 +1,3 @@
+export const fixture = true
+
+export function format(value: string): string

--- a/packages/e2e/fixtures/diagnostics/src/overload-incompatible.ts
+++ b/packages/e2e/fixtures/diagnostics/src/overload-incompatible.ts
@@ -1,0 +1,8 @@
+export const fixture = true
+
+function format(value: string): string
+function format(value: number): number {
+  return value
+}
+
+export const result = format('value')

--- a/packages/e2e/fixtures/diagnostics/src/overload-no-match.ts
+++ b/packages/e2e/fixtures/diagnostics/src/overload-no-match.ts
@@ -1,0 +1,9 @@
+export const fixture = true
+
+function format(value: string): string
+function format(value: number): number
+function format(value: string | number): string | number {
+  return value
+}
+
+export const result = format(true)

--- a/packages/e2e/fixtures/diagnostics/src/override-non-derived.ts
+++ b/packages/e2e/fixtures/diagnostics/src/override-non-derived.ts
@@ -1,0 +1,9 @@
+export const fixture = true
+
+class Store {
+  override getValue(): number {
+    return 1
+  }
+}
+
+export const store = new Store()

--- a/packages/e2e/fixtures/diagnostics/src/parameter-initializer-in-declaration.ts
+++ b/packages/e2e/fixtures/diagnostics/src/parameter-initializer-in-declaration.ts
@@ -1,0 +1,3 @@
+export const fixture = true
+
+export declare function format(value = 'default'): string

--- a/packages/e2e/fixtures/diagnostics/src/required-parameter-after-optional.ts
+++ b/packages/e2e/fixtures/diagnostics/src/required-parameter-after-optional.ts
@@ -1,0 +1,3 @@
+export const fixture = true
+
+export const format = (prefix?: string, value: string): string => `${prefix}${value}`

--- a/packages/e2e/fixtures/diagnostics/src/rest-parameter-not-array.ts
+++ b/packages/e2e/fixtures/diagnostics/src/rest-parameter-not-array.ts
@@ -1,0 +1,3 @@
+export const fixture = true
+
+export const format = (...values: string): string => values

--- a/packages/e2e/fixtures/diagnostics/src/rest-parameter-not-last.ts
+++ b/packages/e2e/fixtures/diagnostics/src/rest-parameter-not-last.ts
@@ -1,0 +1,3 @@
+export const fixture = true
+
+export const format = (...values: string[], suffix: string): string => values.join(',') + suffix

--- a/packages/e2e/fixtures/diagnostics/src/return-outside-function.ts
+++ b/packages/e2e/fixtures/diagnostics/src/return-outside-function.ts
@@ -1,0 +1,3 @@
+export const fixture = true
+
+return 1

--- a/packages/e2e/fixtures/diagnostics/src/setter-optional-parameter.ts
+++ b/packages/e2e/fixtures/diagnostics/src/setter-optional-parameter.ts
@@ -1,0 +1,7 @@
+export const fixture = true
+
+class Store {
+  set value(input?: number) {}
+}
+
+export const store = new Store()

--- a/packages/e2e/fixtures/diagnostics/src/setter-parameter-count.ts
+++ b/packages/e2e/fixtures/diagnostics/src/setter-parameter-count.ts
@@ -1,0 +1,7 @@
+export const fixture = true
+
+class Store {
+  set value(first: number, second: number) {}
+}
+
+export const store = new Store()

--- a/packages/e2e/fixtures/diagnostics/src/setter-rest-parameter.ts
+++ b/packages/e2e/fixtures/diagnostics/src/setter-rest-parameter.ts
@@ -1,0 +1,7 @@
+export const fixture = true
+
+class Store {
+  set value(...input: number[]) {}
+}
+
+export const store = new Store()

--- a/packages/e2e/fixtures/diagnostics/src/setter-return-type.ts
+++ b/packages/e2e/fixtures/diagnostics/src/setter-return-type.ts
@@ -1,0 +1,7 @@
+export const fixture = true
+
+class Store {
+  set value(input: number): void {}
+}
+
+export const store = new Store()

--- a/packages/e2e/fixtures/diagnostics/src/static-constructor.ts
+++ b/packages/e2e/fixtures/diagnostics/src/static-constructor.ts
@@ -1,0 +1,7 @@
+export const fixture = true
+
+class Store {
+  static constructor() {}
+}
+
+export const store = new Store()

--- a/packages/e2e/fixtures/diagnostics/src/static-type-parameter.ts
+++ b/packages/e2e/fixtures/diagnostics/src/static-type-parameter.ts
@@ -1,0 +1,7 @@
+export const fixture = true
+
+class Store<Value> {
+  static value: Value
+}
+
+export const store = Store

--- a/packages/e2e/fixtures/diagnostics/src/super-in-base-class.ts
+++ b/packages/e2e/fixtures/diagnostics/src/super-in-base-class.ts
@@ -1,0 +1,9 @@
+export const fixture = true
+
+class Store {
+  constructor() {
+    super()
+  }
+}
+
+export const store = Store

--- a/packages/e2e/fixtures/diagnostics/src/this-before-super.ts
+++ b/packages/e2e/fixtures/diagnostics/src/this-before-super.ts
@@ -1,0 +1,14 @@
+export const fixture = true
+
+class Base {}
+
+class Derived extends Base {
+  value = 1
+
+  constructor() {
+    this.value = 2
+    super()
+  }
+}
+
+export const derived = Derived

--- a/packages/e2e/fixtures/diagnostics/src/too-many-arguments.ts
+++ b/packages/e2e/fixtures/diagnostics/src/too-many-arguments.ts
@@ -1,0 +1,7 @@
+export const fixture = true
+
+function format(): string {
+  return 'value'
+}
+
+export const result = format('extra')

--- a/packages/e2e/fixtures/diagnostics/src/tuple-rest-not-array.ts
+++ b/packages/e2e/fixtures/diagnostics/src/tuple-rest-not-array.ts
@@ -1,0 +1,3 @@
+export const fixture = true
+
+export type Entry = [...values: string]

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-abstract-member-concrete-class.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-abstract-member-concrete-class.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-abstract-member-concrete-class'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/abstract-member-concrete-class.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('Abstract methods can only appear within an abstract class.')
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-abstract-static-member.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-abstract-static-member.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-abstract-static-member'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/abstract-static-member.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("'static' modifier cannot be used with 'abstract' modifier.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-accessor-type-parameters.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-accessor-type-parameters.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-accessor-type-parameters'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/accessor-type-parameters.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('An accessor cannot have type parameters.')
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-async-return-type.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-async-return-type.ts
@@ -1,0 +1,25 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-async-return-type'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/async-return-type.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText(
+    "The return type of an async function or method must be the global Promise<T> type. Did you mean to write 'Promise<number>'?",
+  )
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-await-non-async.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-await-non-async.ts
@@ -1,0 +1,25 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-await-non-async'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/await-non-async.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText(
+    "'await' expressions are only allowed within async functions and at the top levels of modules.",
+  )
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-await-parameter-initializer.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-await-parameter-initializer.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-await-parameter-initializer'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/await-parameter-initializer.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("'await' expressions cannot be used in a parameter initializer.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-break-outside-loop.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-break-outside-loop.ts
@@ -1,0 +1,25 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-break-outside-loop'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/break-outside-loop.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText(
+    "A 'break' statement can only be used within an enclosing iteration or switch statement.",
+  )
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-catch-type-annotation.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-catch-type-annotation.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-catch-type-annotation'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/catch-type-annotation.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("Catch clause variable type annotation must be 'any' or 'unknown' if specified.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-circular-type-parameter.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-circular-type-parameter.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-circular-type-parameter'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/circular-type-parameter.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("Type parameter 'Input' has a circular constraint.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-const-enum-non-constant.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-const-enum-non-constant.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-const-enum-non-constant'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/const-enum-non-constant.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('const enum member initializers must be constant expressions.')
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-constructor-return-type.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-constructor-return-type.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-constructor-return-type'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/constructor-return-type.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('Type annotation cannot appear on a constructor declaration.')
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-constructor-type-parameters.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-constructor-type-parameters.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-constructor-type-parameters'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/constructor-type-parameters.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('Type parameters cannot appear on a constructor declaration.')
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-continue-outside-loop.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-continue-outside-loop.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-continue-outside-loop'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/continue-outside-loop.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("A 'continue' statement can only be used within an enclosing iteration statement.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-definite-assignment-initializer.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-definite-assignment-initializer.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-definite-assignment-initializer'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/definite-assignment-initializer.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('Declarations with initializers cannot also have definite assignment assertions.')
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-duplicate-label.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-duplicate-label.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-duplicate-label'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/duplicate-label.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("Duplicate label 'block'.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-extends-interface.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-extends-interface.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-extends-interface'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/extends-interface.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("Cannot extend an interface 'Base'. Did you mean 'implements'?")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-function-return-type.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-function-return-type.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-function-return-type'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/function-return-type.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("Type 'string' is not assignable to type 'number'.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-generator-return-type.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-generator-return-type.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-generator-return-type'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/generator-return-type.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("Type 'Generator<any, any, unknown>' is not assignable to type 'number'.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-getter-parameters.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-getter-parameters.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-getter-parameters'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/getter-parameters.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("A 'get' accessor cannot have parameters.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-implements-primitive.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-implements-primitive.ts
@@ -1,0 +1,25 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-implements-primitive'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/implements-primitive.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText(
+    "A class cannot implement a primitive type like 'string'. It can only implement other named object types.",
+  )
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-in-operator-right.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-in-operator-right.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-in-operator-right'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/in-operator-right.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("Type 'number' is not assignable to type 'object'.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-instanceof-left.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-instanceof-left.ts
@@ -1,0 +1,25 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-instanceof-left'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/instanceof-left.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText(
+    "The left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter.",
+  )
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-instanceof-right.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-instanceof-right.ts
@@ -1,0 +1,25 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-instanceof-right'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/instanceof-right.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText(
+    "The right-hand side of an 'instanceof' expression must be either of type 'any', a class, function, or other type assignable to the 'Function' interface type, or an object type with a 'Symbol.hasInstance' method.",
+  )
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-interface-extends-primitive.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-interface-extends-primitive.ts
@@ -1,0 +1,25 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-interface-extends-primitive'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/interface-extends-primitive.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText(
+    "An interface cannot extend a primitive type like 'string'. It can only extend other named object types.",
+  )
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-invalid-break-label.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-invalid-break-label.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-invalid-break-label'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/invalid-break-label.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("A 'break' statement can only jump to a label of an enclosing statement.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-invalid-continue-label.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-invalid-continue-label.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-invalid-continue-label'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/invalid-continue-label.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("A 'continue' statement can only jump to a label of an enclosing iteration statement.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-missing-constructor-argument.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-missing-constructor-argument.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-missing-constructor-argument'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/missing-constructor-argument.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('Expected 1 arguments, but got 0.')
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-missing-super-call.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-missing-super-call.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-missing-super-call'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/missing-super-call.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("Constructors for derived classes must contain a 'super' call.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-new-target-outside-function.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-new-target-outside-function.ts
@@ -1,0 +1,25 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-new-target-outside-function'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/new-target-outside-function.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText(
+    "Meta-property 'new.target' is only allowed in the body of a function declaration, function expression, or constructor.",
+  )
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-non-constructable.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-non-constructable.ts
@@ -1,0 +1,25 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-non-constructable'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/non-constructable.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText(
+    "'new' expression, whose target lacks a construct signature, implicitly has an 'any' type.",
+  )
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-optional-parameter-initializer.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-optional-parameter-initializer.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-optional-parameter-initializer'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/optional-parameter-initializer.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('Parameter cannot have question mark and initializer.')
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-overload-implementation-missing.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-overload-implementation-missing.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-overload-implementation-missing'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/overload-implementation-missing.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('Function implementation is missing or not immediately following the declaration.')
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-overload-incompatible.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-overload-incompatible.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-overload-incompatible'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/overload-incompatible.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('This overload signature is not compatible with its implementation signature.')
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-overload-no-match.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-overload-no-match.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-overload-no-match'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/overload-no-match.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('No overload matches this call.')
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-overload-no-match.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-overload-no-match.ts
@@ -19,5 +19,7 @@ export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Pro
   await expect(problems).toHaveCount(2)
   const problemInfo = problems.nth(1)
   const label = problemInfo.locator('.Label')
-  await expect(label).toHaveText('No overload matches this call.')
+  await expect(label).toHaveText(
+    "No overload matches this call.\n  Overload 1 of 2, '(value: string): string', gave the following error.\n    Argument of type 'boolean' is not assignable to parameter of type 'string'.\n  Overload 2 of 2, '(value: number): number', gave the following error.\n    Argument of type 'boolean' is not assignable to parameter of type 'number'.",
+  )
 }

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-override-non-derived.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-override-non-derived.ts
@@ -1,0 +1,25 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-override-non-derived'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/override-non-derived.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText(
+    "This member cannot have an 'override' modifier because its containing class 'Store' does not extend another class.",
+  )
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-parameter-initializer-in-declaration.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-parameter-initializer-in-declaration.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-parameter-initializer-in-declaration'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/parameter-initializer-in-declaration.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('A parameter initializer is only allowed in a function or constructor implementation.')
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-required-parameter-after-optional.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-required-parameter-after-optional.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-required-parameter-after-optional'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/required-parameter-after-optional.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('A required parameter cannot follow an optional parameter.')
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-rest-parameter-not-array.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-rest-parameter-not-array.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-rest-parameter-not-array'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/rest-parameter-not-array.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('A rest parameter must be of an array type.')
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-rest-parameter-not-last.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-rest-parameter-not-last.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-rest-parameter-not-last'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/rest-parameter-not-last.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('A rest parameter must be last in a parameter list.')
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-return-outside-function.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-return-outside-function.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-return-outside-function'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/return-outside-function.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("A 'return' statement can only be used within a function body.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-setter-optional-parameter.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-setter-optional-parameter.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-setter-optional-parameter'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/setter-optional-parameter.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("A 'set' accessor cannot have an optional parameter.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-setter-parameter-count.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-setter-parameter-count.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-setter-parameter-count'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/setter-parameter-count.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("A 'set' accessor must have exactly one parameter.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-setter-rest-parameter.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-setter-rest-parameter.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-setter-rest-parameter'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/setter-rest-parameter.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("A 'set' accessor cannot have rest parameter.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-setter-return-type.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-setter-return-type.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-setter-return-type'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/setter-return-type.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("A 'set' accessor cannot have a return type annotation.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-static-constructor.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-static-constructor.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-static-constructor'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/static-constructor.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("'static' modifier cannot appear on a constructor declaration.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-static-type-parameter.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-static-type-parameter.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-static-type-parameter'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/static-type-parameter.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('Static members cannot reference class type parameters.')
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-super-in-base-class.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-super-in-base-class.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-super-in-base-class'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/super-in-base-class.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText("'super' can only be referenced in a derived class.")
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-this-before-super.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-this-before-super.ts
@@ -1,0 +1,25 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-this-before-super'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/this-before-super.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText(
+    "'super' must be called before accessing 'this' in the constructor of a derived class.",
+  )
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-too-many-arguments.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-too-many-arguments.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-too-many-arguments'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/too-many-arguments.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('Expected 0 arguments, but got 1.')
+}

--- a/packages/e2e/src/typescript.diagnostics-problems-panel-tuple-rest-not-array.ts
+++ b/packages/e2e/src/typescript.diagnostics-problems-panel-tuple-rest-not-array.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-problems-panel-tuple-rest-not-array'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Problems, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/tuple-rest-not-array.ts`)
+
+  // assert
+  await Panel.open('Problems')
+  await Problems.show()
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  const problemInfo = problems.nth(1)
+  const label = problemInfo.locator('.Label')
+  await expect(label).toHaveText('A rest element type must be an array type.')
+}


### PR DESCRIPTION
Adds 50 focused end-to-end tests for TypeScript diagnostics in the Problems panel, with one minimal fixture per diagnostic.