### PR TITLE
feature: update extension api to 8.75.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "typescript": "^6.0.3"
       },
       "devDependencies": {
-        "@lvce-editor/api": "^8.73.0",
+        "@lvce-editor/api": "^8.75.0",
         "@lvce-editor/eslint-config": "^17.6.0",
         "eslint": "^10.8.0",
         "jest": "^30.4.2",
@@ -2602,12 +2602,13 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/api": {
-      "version": "8.73.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.73.0.tgz",
-      "integrity": "sha512-gaXMFv0s+8/om6VckoP1QmuwJvG2+q2xCDT5E0ryHrnAaxoQ3bQJ5TgcMQenTLYICw+KZH4EwnvBdAfmDO/iPA==",
+      "version": "8.75.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.75.0.tgz",
+      "integrity": "sha512-ub0W95GZVxRmUYpkfGHirV8+UUO15uZCBxkhdgtctzLWuw1SZQO3UEcBqKhTbPsiRCzawclHDXRFR0N9vFGboQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@lvce-editor/command": "^2.0.0",
         "@lvce-editor/rpc": "^6.4.0",
         "@lvce-editor/rpc-registry": "^9.24.0",
         "@lvce-editor/virtual-dom-worker": "^10.0.0"
@@ -14454,7 +14455,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/api": "^8.73.0",
+        "@lvce-editor/api": "^8.75.0",
         "@lvce-editor/rpc": "^6.8.0",
         "@lvce-editor/rpc-registry": "^9.36.0",
         "typescript": "^6.0.3"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "typescript": "^6.0.3"
   },
   "devDependencies": {
-    "@lvce-editor/api": "^8.73.0",
+    "@lvce-editor/api": "^8.75.0",
     "@lvce-editor/eslint-config": "^17.6.0",
     "eslint": "^10.8.0",
     "jest": "^30.4.2",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -28,7 +28,7 @@
     }
   },
   "devDependencies": {
-    "@lvce-editor/api": "^8.73.0",
+    "@lvce-editor/api": "^8.75.0",
     "@lvce-editor/rpc": "^6.8.0",
     "@lvce-editor/rpc-registry": "^9.36.0",
     "typescript": "^6.0.3"


### PR DESCRIPTION
Updates the root and extension API dependencies to 8.75.0 so unused API commands can be tree-shaken from the production bundle.\n\nMeasured extension main output: 102,988 → 72,664 bytes (−30,324); extension.tar.br: 1,510,580 → 1,505,726 bytes (−4,854).