### PR TITLE
test: enable no definition feedback coverage

### DIFF
--- a/packages/e2e/src/typescript.no-definition-found.ts
+++ b/packages/e2e/src/typescript.no-definition-found.ts
@@ -2,9 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'typescript.no-definition-found'
 
-// TODO enable when no-result messaging supports isolated definition providers
-export const skip = 1
-
 export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main, Workspace }) => {
   // arrange
   const fixtureUrl = import.meta.resolve('../fixtures/no-definition-found')


### PR DESCRIPTION
## Summary
- enable the isolated TypeScript provider no-definition UI regression
- verify Go to Definition surfaces the existing editor overlay message

## Verification
- npm run lint
- npm run type-check
- focused headless e2e: typescript.no-definition-found