### PR TITLE
fix: open TypeScript standard library definitions

### DIFF
--- a/packages/e2e/src/typescript.definition.ts
+++ b/packages/e2e/src/typescript.definition.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'typescript.definition'
 
-export const skip = 1
-
 export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main, Workspace }) => {
   // arrange
   const fixtureUrl = import.meta.resolve('../fixtures/definition')

--- a/packages/typescript-worker/src/parts/GetDefinitionFromTsResult2/GetDefinitionFromTsResult2.ts
+++ b/packages/typescript-worker/src/parts/GetDefinitionFromTsResult2/GetDefinitionFromTsResult2.ts
@@ -1,18 +1,37 @@
 import type ts from 'typescript'
 import type { IFileSystem } from '../IFileSystem/IFileSystem.ts'
+import { getLibFileUrl } from '../GetLibFileUrl/GetLibFileUrl.ts'
 import { getPositionAt } from '../GetPositionAt/GetPositionAt.ts'
+import { isLibFile } from '../IsLibFile/IsLibFile.ts'
+import { readLibFile } from '../ReadLibFile/ReadLibFile.ts'
 
 const getUri = (fileName: string) => {
-  if (fileName.includes('/node_modules/@typescript/lib') || fileName.includes('node_modules/@typescript/lib')) {
-    const base = fileName
-      .slice(fileName.lastIndexOf('/') + 1)
-      .replaceAll('-', '.')
-      .replace('.ts', '.d.ts')
-    const almost = new URL(`../../../node_modules/typescript/lib/${base}`, import.meta.url).href
-    const uri = almost.slice(almost.indexOf('/remote') + '/remote'.length)
-    return uri
+  if (isLibFile(fileName)) {
+    const url = new URL(getLibFileUrl(fileName))
+    if (url.pathname.startsWith('/remote/')) {
+      return url.pathname.slice('/remote'.length)
+    }
+    return url.pathname
   }
   return fileName
+}
+
+const getText = async (
+  fileName: string,
+  fs: IFileSystem,
+  readFile: (uri: string) => Promise<string>,
+): Promise<string> => {
+  const cachedText = fs.readFile(fileName)
+  if (cachedText) {
+    return cachedText
+  }
+  if (isLibFile(fileName)) {
+    const libText = readLibFile(fileName)
+    if (libText) {
+      return libText
+    }
+  }
+  return readFile(fileName)
 }
 
 export const getDefinitionFromTsResult2 = async (
@@ -26,7 +45,7 @@ export const getDefinitionFromTsResult2 = async (
   const firstDefinition = tsResult[0]
   const { fileName, textSpan } = firstDefinition
   const uri = getUri(fileName)
-  const text = fs.readFile(fileName) || (await readFile(fileName))
+  const text = await getText(fileName, fs, readFile)
   const startOffset = textSpan.start
   const endOffset = textSpan.start + textSpan.length
   const startPosition = getPositionAt(text, startOffset)

--- a/packages/typescript-worker/src/parts/GetLibFileUrl/GetLibFileUrl.ts
+++ b/packages/typescript-worker/src/parts/GetLibFileUrl/GetLibFileUrl.ts
@@ -17,7 +17,7 @@ export const getLibFileUrl = (uri: string): string => {
     uri
       .slice(index + libStringLength)
       .replaceAll(/[-/]/g, '.')
-      .replaceAll('.ts', '') +
+      .replace(/(?:\.d)?\.ts$/, '') +
     '.d.ts'
 
   return new URL(`../../../node_modules/typescript/lib/${relativePath}`, import.meta.url).href

--- a/packages/typescript-worker/test/GetDefinitionFromTsResult2.test.ts
+++ b/packages/typescript-worker/test/GetDefinitionFromTsResult2.test.ts
@@ -46,3 +46,33 @@ test('returns undefined when TypeScript finds no definition', async () => {
   expect(await getDefinitionFromTsResult2([], fs, readFile)).toBeUndefined()
   expect(readFile).not.toHaveBeenCalled()
 })
+
+test.each([
+  ['lib.es5.d.ts', 'lib.es5.d.ts'],
+  ['node_modules/@typescript/lib-es5.d.ts', 'lib.es5.d.ts'],
+])('converts the TypeScript library target %s to an openable asset URL', async (fileName, expectedBaseName) => {
+  const fs = createFileSystem()
+  fs.writeFile(fileName, 'round')
+  const readFile = jest.fn<(uri: string) => Promise<string>>(async () => 'round')
+
+  const definition = await getDefinitionFromTsResult2(
+    [
+      {
+        containerKind: ts.ScriptElementKind.unknown,
+        containerName: 'Math',
+        fileName,
+        kind: ts.ScriptElementKind.memberFunctionElement,
+        name: 'round',
+        textSpan: {
+          length: 5,
+          start: 0,
+        },
+      },
+    ],
+    fs,
+    readFile,
+  )
+
+  expect(readFile).not.toHaveBeenCalled()
+  expect(definition?.uri).toContain(`/node_modules/typescript/lib/${expectedBaseName}`)
+})

--- a/packages/typescript-worker/test/GetLibFileUrl.test.ts
+++ b/packages/typescript-worker/test/GetLibFileUrl.test.ts
@@ -27,19 +27,19 @@ test('getLibFileUrl - lib.dom.d.ts', () => {
 
 test('getLibFileUrl - with node_modules/@typescript/lib path', () => {
   const result = GetLibFileUrl.getLibFileUrl('node_modules/@typescript/lib/lib.d.ts')
-  expect(result).toContain('node_modules/typescript/lib/lib.lib.d.d.ts')
+  expect(result).toContain('node_modules/typescript/lib/lib.lib.d.ts')
   expect(result).toContain('file://')
 })
 
 test('getLibFileUrl - with node_modules/@typescript/lib path and dashes', () => {
   const result = GetLibFileUrl.getLibFileUrl('node_modules/@typescript/lib/lib-es2015.d.ts')
-  expect(result).toContain('node_modules/typescript/lib/lib.lib.es2015.d.d.ts')
+  expect(result).toContain('node_modules/typescript/lib/lib.lib.es2015.d.ts')
   expect(result).toContain('file://')
 })
 
 test('getLibFileUrl - with node_modules/@typescript/lib path and slashes', () => {
   const result = GetLibFileUrl.getLibFileUrl('node_modules/@typescript/lib/dom/lib.d.ts')
-  expect(result).toContain('node_modules/typescript/lib/lib.dom.lib.d.d.ts')
+  expect(result).toContain('node_modules/typescript/lib/lib.dom.lib.d.ts')
   expect(result).toContain('file://')
 })
 


### PR DESCRIPTION
## Summary
- load standard-library definition text from the bundled TypeScript assets
- convert library targets to editor-openable internal paths
- fix virtual @typescript library names that produced duplicate .d suffixes
- enable the standard-library definition UI regression