### PR TITLE
fix: preserve TypeScript library asset URLs

### DIFF
--- a/packages/e2e/src/typescript.definition.ts
+++ b/packages/e2e/src/typescript.definition.ts
@@ -18,4 +18,8 @@ export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main, Wo
   await expect(mainTabs).toHaveCount(2)
   const mainTabTwo = mainTabs.nth(1)
   await expect(mainTabTwo).toHaveText('lib.dom.d.ts')
+  const editorError = Locator('.TextEditorError')
+  await expect(editorError).toBeHidden()
+  const editorContent = Locator('.EditorContent')
+  await expect(editorContent).toBeVisible()
 }

--- a/packages/typescript-worker/src/parts/GetDefinitionFromTsResult2/GetDefinitionFromTsResult2.ts
+++ b/packages/typescript-worker/src/parts/GetDefinitionFromTsResult2/GetDefinitionFromTsResult2.ts
@@ -5,13 +5,17 @@ import { getPositionAt } from '../GetPositionAt/GetPositionAt.ts'
 import { isLibFile } from '../IsLibFile/IsLibFile.ts'
 import { readLibFile } from '../ReadLibFile/ReadLibFile.ts'
 
+export const toOpenableUri = (libFileUrl: string): string => {
+  const url = new URL(libFileUrl)
+  if (url.protocol === 'http:' || url.protocol === 'https:') {
+    return `fetch://${url.host}${url.pathname}${url.search}${url.hash}`
+  }
+  return libFileUrl
+}
+
 const getUri = (fileName: string) => {
   if (isLibFile(fileName)) {
-    const url = new URL(getLibFileUrl(fileName))
-    if (url.pathname.startsWith('/remote/')) {
-      return url.pathname.slice('/remote'.length)
-    }
-    return url.pathname
+    return toOpenableUri(getLibFileUrl(fileName))
   }
   return fileName
 }

--- a/packages/typescript-worker/test/GetDefinitionFromTsResult2.test.ts
+++ b/packages/typescript-worker/test/GetDefinitionFromTsResult2.test.ts
@@ -1,7 +1,11 @@
 import { expect, jest, test } from '@jest/globals'
 import ts from 'typescript'
 import { createFileSystem } from '../src/parts/CreateFileSystem/CreateFileSystem.ts'
-import { getDefinitionFromTsResult2 } from '../src/parts/GetDefinitionFromTsResult2/GetDefinitionFromTsResult2.ts'
+import {
+  getDefinitionFromTsResult2,
+  toOpenableUri,
+} from '../src/parts/GetDefinitionFromTsResult2/GetDefinitionFromTsResult2.ts'
+import { getLibFileUrl } from '../src/parts/GetLibFileUrl/GetLibFileUrl.ts'
 
 test('loads the target file and converts its symbol span', async () => {
   const fs = createFileSystem()
@@ -48,31 +52,43 @@ test('returns undefined when TypeScript finds no definition', async () => {
 })
 
 test.each([
-  ['lib.es5.d.ts', 'lib.es5.d.ts'],
-  ['node_modules/@typescript/lib-es5.d.ts', 'lib.es5.d.ts'],
-])('converts the TypeScript library target %s to an openable asset URL', async (fileName, expectedBaseName) => {
-  const fs = createFileSystem()
-  fs.writeFile(fileName, 'round')
-  const readFile = jest.fn<(uri: string) => Promise<string>>(async () => 'round')
-
-  const definition = await getDefinitionFromTsResult2(
-    [
-      {
-        containerKind: ts.ScriptElementKind.unknown,
-        containerName: 'Math',
-        fileName,
-        kind: ts.ScriptElementKind.memberFunctionElement,
-        name: 'round',
-        textSpan: {
-          length: 5,
-          start: 0,
-        },
-      },
-    ],
-    fs,
-    readFile,
-  )
-
-  expect(readFile).not.toHaveBeenCalled()
-  expect(definition?.uri).toContain(`/node_modules/typescript/lib/${expectedBaseName}`)
+  [
+    'http://localhost:3000/extensions/typescript/lib/lib.es5.d.ts',
+    'fetch://localhost:3000/extensions/typescript/lib/lib.es5.d.ts',
+  ],
+  ['https://example.com/lib.es5.d.ts?version=1#round', 'fetch://example.com/lib.es5.d.ts?version=1#round'],
+  ['lvce://-/abc/extensions/typescript/lib/lib.es5.d.ts', 'lvce://-/abc/extensions/typescript/lib/lib.es5.d.ts'],
+  ['file:///extension/typescript/lib/lib.es5.d.ts', 'file:///extension/typescript/lib/lib.es5.d.ts'],
+])('converts the library asset URL %s to %s', (libFileUrl, expected) => {
+  expect(toOpenableUri(libFileUrl)).toBe(expected)
 })
+
+test.each(['lib.es5.d.ts', 'node_modules/@typescript/lib-es5.d.ts'])(
+  'converts the TypeScript library target %s to its complete openable asset URL',
+  async (fileName) => {
+    const fs = createFileSystem()
+    fs.writeFile(fileName, 'round')
+    const readFile = jest.fn<(uri: string) => Promise<string>>(async () => 'round')
+
+    const definition = await getDefinitionFromTsResult2(
+      [
+        {
+          containerKind: ts.ScriptElementKind.unknown,
+          containerName: 'Math',
+          fileName,
+          kind: ts.ScriptElementKind.memberFunctionElement,
+          name: 'round',
+          textSpan: {
+            length: 5,
+            start: 0,
+          },
+        },
+      ],
+      fs,
+      readFile,
+    )
+
+    expect(readFile).not.toHaveBeenCalled()
+    expect(definition?.uri).toBe(getLibFileUrl(fileName))
+  },
+)


### PR DESCRIPTION
## Summary

- preserve `lvce://` and `file://` library asset URLs so the renderer can resolve installed Electron resources
- translate HTTP(S) extension assets to the editor-supported `fetch://` scheme
- strengthen definition coverage to reject error-only editor tabs