### PR TITLE
fix: tolerate missing declaration targets

### DIFF
--- a/packages/e2e/fixtures/diagnostics-missing-declaration-target/node_modules/incomplete-library/index.d.ts
+++ b/packages/e2e/fixtures/diagnostics-missing-declaration-target/node_modules/incomplete-library/index.d.ts
@@ -1,0 +1,1 @@
+export { IExperimentationFilterProvider } from './contracts/IExperimentationFilterProvider.js'

--- a/packages/e2e/fixtures/diagnostics-missing-declaration-target/node_modules/incomplete-library/package.json
+++ b/packages/e2e/fixtures/diagnostics-missing-declaration-target/node_modules/incomplete-library/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "incomplete-library",
+  "version": "1.0.0",
+  "types": "index.d.ts"
+}

--- a/packages/e2e/fixtures/diagnostics-missing-declaration-target/package.json
+++ b/packages/e2e/fixtures/diagnostics-missing-declaration-target/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "diagnostics-missing-declaration-target",
+  "version": "1.0.0",
+  "type": "module"
+}

--- a/packages/e2e/fixtures/diagnostics-missing-declaration-target/src/assignment.ts
+++ b/packages/e2e/fixtures/diagnostics-missing-declaration-target/src/assignment.ts
@@ -1,0 +1,3 @@
+import type { IExperimentationFilterProvider } from 'incomplete-library'
+
+export const assignment: IExperimentationFilterProvider = { enabled: true }

--- a/packages/e2e/fixtures/diagnostics-missing-declaration-target/src/main.ts
+++ b/packages/e2e/fixtures/diagnostics-missing-declaration-target/src/main.ts
@@ -1,0 +1,3 @@
+export const value = true
+
+export const text: string = 1

--- a/packages/e2e/fixtures/diagnostics-missing-declaration-target/tsconfig.json
+++ b/packages/e2e/fixtures/diagnostics-missing-declaration-target/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "types": []
+  }
+}

--- a/packages/e2e/src/typescript.diagnostics-missing-declaration-target.ts
+++ b/packages/e2e/src/typescript.diagnostics-missing-declaration-target.ts
@@ -1,0 +1,31 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-missing-declaration-target'
+
+export const test: Test = async ({ Editor, FileSystem, Main, Settings, Workspace }) => {
+  // arrange
+  const fixtureUrl = import.meta.resolve('../fixtures/diagnostics-missing-declaration-target')
+  const workspaceUrl = await FileSystem.loadFixture(fixtureUrl)
+  await Workspace.setPath(workspaceUrl)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${workspaceUrl}/src/main.ts`)
+
+  // assert
+  const uri = `${workspaceUrl}/src/main.ts`
+  const expectedDiagnostics = [
+    {
+      code: 2322,
+      columnIndex: 13,
+      endColumnIndex: 17,
+      endRowIndex: 2,
+      message: "Type 'number' is not assignable to type 'string'.",
+      rowIndex: 2,
+      source: 'ts',
+      type: 'error',
+      uri,
+    },
+  ] as const
+  await Editor.shouldHaveDiagnostics(expectedDiagnostics)
+}

--- a/packages/typescript-worker/src/parts/CreateModuleResolver/CreateModuleResolver.ts
+++ b/packages/typescript-worker/src/parts/CreateModuleResolver/CreateModuleResolver.ts
@@ -78,8 +78,13 @@ const getRelativeModuleNames = (containingFile: string, text: string): readonly 
   return [text]
 }
 
-const getExistingRelativeModuleName = (syncRpc: Readonly<SyncRpc>, containingFile: string, text: string): string => {
+const getExistingRelativeModuleName = (
+  syncRpc: Readonly<SyncRpc>,
+  containingFile: string,
+  text: string,
+): string | undefined => {
   const relativeModuleNames = getRelativeModuleNames(containingFile, text)
+  let syncAccessUnavailable = false
   for (const relativeModuleName of relativeModuleNames) {
     const resolvedFileName = resolveRelativePath(containingFile, relativeModuleName)
     try {
@@ -87,10 +92,11 @@ const getExistingRelativeModuleName = (syncRpc: Readonly<SyncRpc>, containingFil
         return relativeModuleName
       }
     } catch {
-      // Fall back to the preferred candidate when synchronous file access is unavailable.
+      syncAccessUnavailable = true
     }
   }
-  return relativeModuleNames[0]
+  // Preserve the legacy fallback only when synchronous file access itself is unavailable.
+  return syncAccessUnavailable ? relativeModuleNames[0] : undefined
 }
 
 const resolveModuleNameRelative = (
@@ -99,6 +105,11 @@ const resolveModuleNameRelative = (
   text: string,
 ): ResolvedModuleWithFailedLookupLocations => {
   const relativeModuleName = getExistingRelativeModuleName(syncRpc, containingFile, text)
+  if (!relativeModuleName) {
+    return {
+      resolvedModule: undefined,
+    }
+  }
   const resolvedFileName = resolveRelativePath(containingFile, relativeModuleName)
   const extension = getExtension(resolvedFileName)
   return {

--- a/packages/typescript-worker/src/parts/IFileSystem/IFileSystem.ts
+++ b/packages/typescript-worker/src/parts/IFileSystem/IFileSystem.ts
@@ -2,6 +2,6 @@ export interface IFileSystem {
   readonly getScriptFileNames: () => readonly string[]
   readonly getScriptVersion: (uri: string) => string
   readonly getVersion: () => string
-  readonly readFile: (uri: string) => string
+  readonly readFile: (uri: string) => string | undefined
   readonly writeFile: (uri: string, content: string) => void
 }

--- a/packages/typescript-worker/src/parts/TypeScriptLanguageHost/TypeScriptLanguageHost.ts
+++ b/packages/typescript-worker/src/parts/TypeScriptLanguageHost/TypeScriptLanguageHost.ts
@@ -106,8 +106,15 @@ export const create = (
         }
         return ts.ScriptSnapshot.fromString(content)
       }
-      const content = fileSystem.readFile(fileName) || syncRpc.invokeSync('SyncApi.readFileSync', fileName)
-      if (!content) {
+      let content = fileSystem.readFile(fileName)
+      if (content === undefined) {
+        try {
+          content = syncRpc.invokeSync('SyncApi.readFileSync', fileName)
+        } catch {
+          return undefined
+        }
+      }
+      if (content === undefined) {
         return undefined
       }
       const snapshot = ts.ScriptSnapshot.fromString(content)
@@ -121,8 +128,11 @@ export const create = (
       return dirents
     },
     readFile(path) {
-      const result = syncRpc.invokeSync('SyncApi.readFileSync', path)
-      return result
+      try {
+        return syncRpc.invokeSync('SyncApi.readFileSync', path)
+      } catch {
+        return undefined
+      }
     },
     resolveModuleNameLiterals(
       moduleLiterals,

--- a/packages/typescript-worker/test/CreateModuleResolver.test.ts
+++ b/packages/typescript-worker/test/CreateModuleResolver.test.ts
@@ -28,7 +28,7 @@ test('createModuleResolver should return undefined for non-fully specified modul
   }
 
   const mockSyncRpc = {
-    invokeSync: () => '',
+    invokeSync: () => true,
   }
 
   const resolver = createModuleResolver(mockSyncRpc)
@@ -58,7 +58,7 @@ test('createModuleResolver should handle relative imports starting with ./', () 
   }
 
   const mockSyncRpc = {
-    invokeSync: () => '',
+    invokeSync: () => true,
   }
 
   const resolver = createModuleResolver(mockSyncRpc)
@@ -78,7 +78,7 @@ test('createModuleResolver should handle relative imports starting with ../', ()
   }
 
   const mockSyncRpc = {
-    invokeSync: () => '',
+    invokeSync: () => true,
   }
 
   const resolver = createModuleResolver(mockSyncRpc)
@@ -98,7 +98,7 @@ test('createModuleResolver should normalize relative imports from file uris', ()
   }
 
   const mockSyncRpc = {
-    invokeSync: () => '',
+    invokeSync: () => true,
   }
 
   const resolver = createModuleResolver(mockSyncRpc)
@@ -124,7 +124,7 @@ test('createModuleResolver should preserve absolute file paths for relative impo
   }
 
   const mockSyncRpc = {
-    invokeSync: () => '',
+    invokeSync: () => true,
   }
 
   const resolver = createModuleResolver(mockSyncRpc)
@@ -146,7 +146,7 @@ test('createModuleResolver should preserve absolute file paths for relative impo
 
 test('createModuleResolver should resolve .ts imports from declaration files in node_modules as .d.ts files', () => {
   const resolver = createModuleResolver({
-    invokeSync: () => '',
+    invokeSync: () => true,
   })
 
   const result = resolver('./parts/Activation/Activation.ts', '/project/node_modules/abc/index.d.ts', {
@@ -160,7 +160,7 @@ test('createModuleResolver should resolve .ts imports from declaration files in 
 
 test('createModuleResolver should resolve extensionless imports from declaration files in node_modules as .d.ts files', () => {
   const resolver = createModuleResolver({
-    invokeSync: () => '',
+    invokeSync: () => true,
   })
 
   const result = resolver('./dispatcher', '/project/node_modules/undici-types/index.d.ts', {
@@ -212,7 +212,7 @@ test('createModuleResolver should resolve declaration imports ending in .d', () 
 
 test('createModuleResolver should preserve .d.ts imports from declaration files in node_modules', () => {
   const resolver = createModuleResolver({
-    invokeSync: () => '',
+    invokeSync: () => true,
   })
 
   const result = resolver('./parts/Activation/Activation.d.ts', '/project/node_modules/abc/index.d.ts', {
@@ -224,7 +224,7 @@ test('createModuleResolver should preserve .d.ts imports from declaration files 
 
 test('createModuleResolver should preserve .ts imports outside node_modules', () => {
   const resolver = createModuleResolver({
-    invokeSync: () => '',
+    invokeSync: () => true,
   })
 
   const result = resolver('./parts/Activation/Activation.ts', '/project/src/index.d.ts', {
@@ -617,6 +617,21 @@ test('createModuleResolver should resolve declaration package directory imports'
 
   expect(result.resolvedModule?.extension).toBe('.d.ts')
   expect(result.resolvedModule?.resolvedFileName).toBe('/project/node_modules/@types/react/index.d.ts')
+})
+
+test('createModuleResolver should not resolve a missing relative target from a declaration package', () => {
+  const syncRpc = createWorkspaceSyncRpc({
+    '/project/node_modules/incomplete-library/index.d.ts': "export { MissingType } from './contracts/MissingType.js'",
+  })
+  const resolver = createModuleResolver(syncRpc, TypeScript)
+
+  const result = resolver(
+    './contracts/MissingType.js',
+    '/project/node_modules/incomplete-library/index.d.ts',
+    bundlerOptions,
+  )
+
+  expect(result.resolvedModule).toBeUndefined()
 })
 
 test('createModuleResolver should resolve a CommonJS package whose main entry is a directory', () => {

--- a/packages/typescript-worker/test/TypeScriptLanguageHost.test.ts
+++ b/packages/typescript-worker/test/TypeScriptLanguageHost.test.ts
@@ -329,6 +329,43 @@ test('getScriptFileNames should return configured and file system script names',
   expect(host.getScriptFileNames?.()).toEqual(['configured.ts', 'file1.ts', 'file2.ts'])
 })
 
+test('missing file reads should return undefined', () => {
+  const fileSystem = createFileSystem()
+  const mockSyncRpc = {
+    invokeSync(method: string) {
+      if (method === 'SyncApi.readFileSync') {
+        throw new Error('File not found')
+      }
+      throw new Error(`unexpected method ${method}`)
+    },
+  }
+  const host = create(TypeScript, fileSystem, mockSyncRpc, {
+    errors: [],
+    fileNames: [],
+    options: {},
+  })
+
+  expect(host.getScriptSnapshot?.('/project/missing.ts')).toBeUndefined()
+  expect(host.readFile?.('/project/missing.ts')).toBeUndefined()
+})
+
+test('getScriptSnapshot should preserve empty in-memory files', () => {
+  const fileSystem = createFileSystem()
+  fileSystem.writeFile('/project/empty.ts', '')
+  const mockSyncRpc = {
+    invokeSync() {
+      throw new Error('unexpected synchronous file read')
+    },
+  }
+  const host = create(TypeScript, fileSystem, mockSyncRpc, {
+    errors: [],
+    fileNames: [],
+    options: {},
+  })
+
+  expect(host.getScriptSnapshot?.('/project/empty.ts')?.getLength()).toBe(0)
+})
+
 test('getScriptVersion should return string version', () => {
   globalThis.rpc = {
     invoke: jest.fn(() => Promise.resolve()),


### PR DESCRIPTION
## Details

TypeScript declaration packages can reference files that are absent from the installed package. The custom relative-module fallback treated those verified-missing paths as resolved modules, and the language-service host then allowed the synchronous file-read exception to abort diagnostics.

## Change

- leave verified-missing relative declaration targets unresolved
- return undefined when a language-service file disappears instead of throwing
- preserve empty in-memory files without falling through to disk
- add unit coverage and an end-to-end fixture matching the incomplete tas-client package shape

## Validation

- 236 unit tests passed; 9 repository-declared skips
- 158 headless end-to-end tests passed; 9 repository-declared skips; 0 failures
- type-check passed
- lint and Prettier passed
- build passed